### PR TITLE
upd 0.7.6 mobile-responsive layout, auto-login, and bug fixes

### DIFF
--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -102,6 +102,10 @@
   "useEdupageDefault": { "message": "Použít výchozí EduPage" },
   "secondHalfEnd": { "message": "Datum konce druhého pololetí" },
   "secondHalfEndDesc": { "message": "Přepište, kdy končí druhé pololetí pro předpovězenou docházku ve známkách. Ponechte prázdné pro použití výchozího data konce EduPage pro aktuální školní rok." },
+  "autoLogin": { "message": "Automatické přihlášení" },
+  "autoLoginDesc": { "message": "Automaticky odešle přihlašovací formulář, když prohlížeč vyplní uložené jméno a heslo." },
+  "toggleAutoLogin": { "message": "Přepnout automatické přihlášení" },
+  "autoLoginSubmitting": { "message": "Automatické přihlašování…" },
 
   "groupDebug": { "message": "Ladění" },
   "mobileResponsive": { "message": "Responzivní rozvržení pro mobil" },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -102,6 +102,10 @@
   "useEdupageDefault": { "message": "Use EduPage Default" },
   "secondHalfEnd": { "message": "Second Halfyear End Date" },
   "secondHalfEndDesc": { "message": "Override when the second halfyear ends for predicted attendance in grades. Leave this empty to use EduPage's default end date for the current school year." },
+  "autoLogin": { "message": "Auto-Login" },
+  "autoLoginDesc": { "message": "Automatically submit the login form when the browser has autofilled your saved username and password." },
+  "toggleAutoLogin": { "message": "Toggle auto-login" },
+  "autoLoginSubmitting": { "message": "Auto-logging in…" },
 
   "groupDebug": { "message": "Debug" },
   "mobileResponsive": { "message": "Mobile-Responsive Layout" },

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -102,6 +102,10 @@
   "useEdupageDefault": { "message": "Použiť predvolené EduPage" },
   "secondHalfEnd": { "message": "Dátum konca druhého polroka" },
   "secondHalfEndDesc": { "message": "Prepíšte, kedy končí druhý polrok pre predpovedanú dochádzku v známkach. Ponechajte prázdne, aby sa použil predvolený dátum konca EduPage pre aktuálny školský rok." },
+  "autoLogin": { "message": "Automatické prihlásenie" },
+  "autoLoginDesc": { "message": "Automaticky odošle prihlasovací formulár, keď prehliadač vyplní uložené meno a heslo." },
+  "toggleAutoLogin": { "message": "Prepnúť automatické prihlásenie" },
+  "autoLoginSubmitting": { "message": "Automatické prihlasovanie…" },
 
   "groupDebug": { "message": "Ladenie" },
   "mobileResponsive": { "message": "Responzívne rozloženie pre mobil" },

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "__MSG_extName__",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "manifest_version": 3,
   "browser_specific_settings": {
     "gecko": {

--- a/manifest.json
+++ b/manifest.json
@@ -53,7 +53,8 @@
         "scripts/timetable-sync.js",
         "scripts/timetable-enhancer.js",
         "scripts/grades-enhancer.js",
-        "scripts/attendance-enhancer.js"
+        "scripts/attendance-enhancer.js",
+        "scripts/autologin.js"
       ],
       "run_at": "document_start",
       "all_frames": true,

--- a/menu/menu.js
+++ b/menu/menu.js
@@ -12,6 +12,9 @@ const THEME_KEY = "themeMode";
 const CUSTOM_THEME_KEY = "customThemeColors";
 const CLEAN_UI_KEY = "cleanUiEnabled";
 const HIDE_HELP_TEXT_KEY = "hideHelpTextEnabled";
+const MOBILE_RESPONSIVE_KEY = "eeMobileResponsiveEnabled";
+const ROZVRH_ROOM_CHANGE_COLOR_KEY = "eeRozvrhRoomChangeColor";
+const ROZVRH_SUBSTITUTION_COLOR_KEY = "eeRozvrhSubstitutionColor";
 const UPDATE_STATUS_KEY = "eeUpdateStatus";
 const REPO_URL = "https://github.com/Alexosavrua/Edupage-Extras";
 const THEMES = ["dark", "ocean", "forest", "emerald", "pink", "purple", "custom", "light"];
@@ -104,7 +107,7 @@ toggle.addEventListener("change", () => {
 	const enabled = toggle.checked;
 	chrome.storage.local.set({ [STORAGE_KEY]: enabled });
 
-	chrome.storage.local.get([THEME_KEY, CUSTOM_THEME_KEY, CLEAN_UI_KEY, HIDE_HELP_TEXT_KEY], (result) => {
+	chrome.storage.local.get([THEME_KEY, CUSTOM_THEME_KEY, CLEAN_UI_KEY, HIDE_HELP_TEXT_KEY, MOBILE_RESPONSIVE_KEY, ROZVRH_ROOM_CHANGE_COLOR_KEY, ROZVRH_SUBSTITUTION_COLOR_KEY], (result) => {
 		customTheme = normalizeCustomTheme(result[CUSTOM_THEME_KEY]);
 		applyMenuTheme(result[THEME_KEY], enabled, customTheme);
 		chrome.tabs.query({ url: "*://*.edupage.org/*" }, (tabs) => {
@@ -117,6 +120,9 @@ toggle.addEventListener("change", () => {
 						customTheme,
 						cleanUiEnabled: result[CLEAN_UI_KEY] === true,
 						hideHelpTextEnabled: result[HIDE_HELP_TEXT_KEY] === true,
+						mobileResponsiveEnabled: result[MOBILE_RESPONSIVE_KEY] === true,
+						rozvrhRoomChangeColor: result[ROZVRH_ROOM_CHANGE_COLOR_KEY],
+						rozvrhSubstitutionColor: result[ROZVRH_SUBSTITUTION_COLOR_KEY],
 					}, () => {
 						void chrome.runtime.lastError;
 					});

--- a/menu/settings.css
+++ b/menu/settings.css
@@ -791,3 +791,12 @@ input[type="checkbox"]:disabled {
         width: 100%;
     }
 }
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+    }
+}

--- a/menu/settings.html
+++ b/menu/settings.html
@@ -183,6 +183,18 @@
           </label>
         </div>
 
+        <div class="setting-row">
+          <div>
+            <h3 data-i18n="mobileResponsive">Mobile-Responsive Layout</h3>
+            <p data-i18n="mobileResponsiveDesc">Inject structural CSS (flex-wrap, scrollable tables, scaled sidebar/fonts) to make Edupage usable on small screens. Off by default — not fully verified on every page yet.</p>
+          </div>
+          <label class="switch switch-compact" for="MobileResponsiveCheckbox">
+            <input type="checkbox" id="MobileResponsiveCheckbox">
+            <span class="switch-track" aria-hidden="true"></span>
+            <span class="sr-only" data-i18n="toggleMobileResponsive">Toggle mobile-responsive layout</span>
+          </label>
+        </div>
+
       </section>
 
       <section class="setting-group" id="panel-features" role="tabpanel" aria-labelledby="features-heading nav-features" tabindex="0" hidden>
@@ -286,6 +298,18 @@
           </div>
         </div>
 
+        <div class="setting-row">
+          <div>
+            <h3 data-i18n="autoLogin">Auto-Login</h3>
+            <p data-i18n="autoLoginDesc">Automatically submit the login form when the browser has autofilled your saved username and password.</p>
+          </div>
+          <label class="switch switch-compact" for="AutoLoginCheckbox">
+            <input type="checkbox" id="AutoLoginCheckbox">
+            <span class="switch-track" aria-hidden="true"></span>
+            <span class="sr-only" data-i18n="toggleAutoLogin">Toggle auto-login</span>
+          </label>
+        </div>
+
       </section>
 
       <section class="setting-group" id="panel-timetable" role="tabpanel" aria-labelledby="timetable-heading nav-timetable" tabindex="0" hidden>
@@ -352,18 +376,6 @@
 
       <section class="setting-group" id="panel-debug" role="tabpanel" aria-labelledby="debug-heading nav-debug" tabindex="0" hidden>
         <h2 id="debug-heading" data-i18n="groupDebug">Debug</h2>
-
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="mobileResponsive">Mobile-Responsive Layout</h3>
-            <p data-i18n="mobileResponsiveDesc">Inject structural CSS (flex-wrap, scrollable tables, scaled sidebar/fonts) to make Edupage usable on small screens. Off by default — not fully verified on every page yet.</p>
-          </div>
-          <label class="switch switch-compact" for="MobileResponsiveCheckbox">
-            <input type="checkbox" id="MobileResponsiveCheckbox">
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleMobileResponsive">Toggle mobile-responsive layout</span>
-          </label>
-        </div>
 
         <div class="setting-row">
           <div>

--- a/menu/settings.js
+++ b/menu/settings.js
@@ -46,6 +46,7 @@ const resetActivityShieldButton = document.getElementById("ResetActivityShieldBu
 const reloadEdupageTabsButton = document.getElementById("ReloadEdupageTabsButton");
 const experimentalSaveStatus = document.getElementById("ExperimentalSaveStatus");
 const mobileResponsiveToggle = document.getElementById("MobileResponsiveCheckbox");
+const autoLoginToggle = document.getElementById("AutoLoginCheckbox");
 const previewUpdateToastButton = document.getElementById("PreviewUpdateToastButton");
 const STORAGE_KEY = "darkModeEnabled";
 const THEME_KEY = "themeMode";
@@ -70,6 +71,7 @@ const THEME_TOGGLE_COMMAND = "toggle-theme-mode";
 const REPO_URL = "https://github.com/Alexosavrua/Edupage-Extras";
 const ACTIVITY_SHIELD_COMMAND = "toggle-stay-active-mode";
 const MOBILE_RESPONSIVE_KEY = "eeMobileResponsiveEnabled";
+const AUTOLOGIN_KEY = "eeAutoLoginEnabled";
 const activityShieldSettings = [
 	["ActivityShieldEnabled", "eeActivityShieldEnabled"],
 	["ActivityVisibilityState", "eeActivityShieldVisibilityState"],
@@ -932,6 +934,15 @@ if (mobileResponsiveToggle) {
 	mobileResponsiveToggle.addEventListener("change", () => {
 		chrome.storage.local.set({ [MOBILE_RESPONSIVE_KEY]: mobileResponsiveToggle.checked });
 		notifyEdupageTabs();
+	});
+}
+
+if (autoLoginToggle) {
+	chrome.storage.local.get([AUTOLOGIN_KEY], (result) => {
+		autoLoginToggle.checked = result[AUTOLOGIN_KEY] === true;
+	});
+	autoLoginToggle.addEventListener("change", () => {
+		chrome.storage.local.set({ [AUTOLOGIN_KEY]: autoLoginToggle.checked });
 	});
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edupage-extras",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edupage-extras",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "devDependencies": {
         "web-ext": "^8.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "edupage-extras",
   "private": true,
-  "version": "0.7.5",
+  "version": "0.7.6",
   "scripts": {
     "version": "node scripts-dev/sync-version.js && git add manifest.json",
     "sync-version": "node scripts-dev/sync-version.js",

--- a/scripts/activity-shield-bridge.js
+++ b/scripts/activity-shield-bridge.js
@@ -95,7 +95,9 @@
     const indicator = ensureIndicator();
     indicator.style.display = visible ? "block" : "none";
     indicator.style.background = enabled ? "#89b4fa" : "#f38ba8";
-    indicator.title = enabled ? "Activity Shield active" : "Activity Shield paused";
+    const label = enabled ? "Activity Shield active" : "Activity Shield paused";
+    indicator.title = label;
+    indicator.setAttribute("aria-label", label);
   }
 
   function applyPrefs(prefs) {

--- a/scripts/attendance-enhancer.js
+++ b/scripts/attendance-enhancer.js
@@ -473,7 +473,6 @@
   function init() {
     injectStyles();
     initStorage();
-    enhanceAttendanceTable();
     initObserver();
   }
 

--- a/scripts/autologin.js
+++ b/scripts/autologin.js
@@ -1,0 +1,149 @@
+(function () {
+  "use strict";
+
+  if (window.top !== window) return;
+  if (!/^\/login(?:\/|$)/i.test(window.location.pathname)) return;
+
+  const AUTOLOGIN_KEY = "eeAutoLoginEnabled";
+  const STYLE_ID = "ee-autologin-style";
+  let autoLoginEnabled = false;
+  let submitted = false;
+
+  function injectStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      .ee-autologin-badge {
+        position: fixed;
+        bottom: 12px;
+        left: 12px;
+        z-index: 2147483000;
+        padding: 6px 12px;
+        border-radius: 6px;
+        background: rgba(0, 0, 0, 0.7);
+        color: #e0e0e0;
+        font: 12px/1.4 -apple-system, "Segoe UI", Roboto, sans-serif;
+        pointer-events: none;
+        opacity: 1;
+        transition: opacity 0.4s ease;
+      }
+      .ee-autologin-badge.ee-fade {
+        opacity: 0;
+      }
+    `;
+    (document.head || document.documentElement).appendChild(style);
+  }
+
+  function showBadge(text) {
+    injectStyles();
+    let badge = document.querySelector(".ee-autologin-badge");
+    if (!badge) {
+      badge = document.createElement("div");
+      badge.className = "ee-autologin-badge";
+      badge.setAttribute("role", "status");
+      document.body.appendChild(badge);
+    }
+    badge.textContent = text;
+    badge.classList.remove("ee-fade");
+    setTimeout(() => badge.classList.add("ee-fade"), 3000);
+    setTimeout(() => badge.remove(), 3500);
+  }
+
+  function findLoginForm() {
+    const passwordInput = document.querySelector(
+      'input[type="password"]:not([hidden]):not([style*="display: none"])'
+    );
+    if (!passwordInput) return null;
+
+    const form = passwordInput.closest("form");
+    const container = form || document.body;
+
+    const usernameInput = container.querySelector(
+      'input[type="text"], input[type="email"], input:not([type])'
+    );
+    if (!usernameInput) return null;
+
+    const submitButton =
+      container.querySelector('button[type="submit"]') ||
+      container.querySelector('input[type="submit"]') ||
+      container.querySelector('button:not([type="button"]):not([type="reset"])');
+
+    return { usernameInput, passwordInput, submitButton, form };
+  }
+
+  function isFieldFilled(input) {
+    if (input.value && input.value.trim().length > 0) return true;
+
+    try {
+      const bg = window.getComputedStyle(input).backgroundColor;
+      if (bg && /rgb\(232,\s*240,\s*254\)/.test(bg)) return true;
+    } catch (_) { /* ignore */ }
+
+    return false;
+  }
+
+  function tryAutoSubmit() {
+    if (submitted || !autoLoginEnabled) return;
+
+    const elements = findLoginForm();
+    if (!elements) return;
+
+    const { usernameInput, passwordInput, submitButton, form } = elements;
+
+    if (!isFieldFilled(usernameInput) || !isFieldFilled(passwordInput)) return;
+
+    submitted = true;
+
+    showBadge(chrome.i18n.getMessage("autoLoginSubmitting") || "Auto-logging in…");
+
+    setTimeout(() => {
+      if (submitButton) {
+        submitButton.click();
+      } else if (form) {
+        form.requestSubmit();
+      }
+    }, 200);
+  }
+
+  function startWatching() {
+    let attempts = 0;
+    const maxAttempts = 40;
+    const interval = 250;
+
+    const timer = setInterval(() => {
+      attempts += 1;
+      if (submitted || attempts >= maxAttempts) {
+        clearInterval(timer);
+        return;
+      }
+      tryAutoSubmit();
+    }, interval);
+
+    const observer = new MutationObserver(() => {
+      if (!submitted) tryAutoSubmit();
+    });
+
+    if (document.body) {
+      observer.observe(document.body, { childList: true, subtree: true });
+    } else {
+      document.addEventListener("DOMContentLoaded", () => {
+        observer.observe(document.body, { childList: true, subtree: true });
+      }, { once: true });
+    }
+  }
+
+  function init() {
+    chrome.storage.local.get([AUTOLOGIN_KEY], (result) => {
+      autoLoginEnabled = result[AUTOLOGIN_KEY] === true;
+      if (!autoLoginEnabled) return;
+      startWatching();
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -552,7 +552,7 @@ function maybeNotify(status) {
 
       chrome.notifications.create(`ee-update-${status.latestVersion}`, {
         type: "basic",
-        iconUrl: "images/placeholder_icon.png",
+        iconUrl: "images/Edupage-Extras.png",
         title: "Edupage Extras update available",
         message: `Version ${status.latestVersion} is available. Pull the latest project from GitHub.`,
         buttons: [{ title: "Open GitHub" }],

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -810,49 +810,354 @@ function buildDarkCSS() {
   `;
 }
 
-// Debug-only, off by default — structural layout fixes only (wrapping,
-// scrolling, scaling), nothing content-dependent, so it doesn't need exam-day
-// page states to verify against. Scoped under a max-width media query so it
-// has zero effect on desktop regardless of the toggle.
 function buildMobileResponsiveCSS() {
+  const M = "html.ee-mobile-responsive";
   return `
     @media (max-width: 768px) {
-      html.ee-mobile-responsive body {
+      /* ── Global ────────────────────────────────────── */
+      ${M} body {
         overflow-x: hidden !important;
+        -webkit-text-size-adjust: 100% !important;
       }
 
-      html.ee-mobile-responsive .userTopDivInner,
-      html.ee-mobile-responsive .wmaxL1,
-      html.ee-mobile-responsive .userRozvrh {
+      /* ── Fixed-width containers → fluid ────────────── */
+      ${M} .userTopDivInner,
+      ${M} .wmaxL1,
+      ${M} .userRozvrh,
+      ${M} .skinContent,
+      ${M} .userContentInner,
+      ${M} .mainBox,
+      ${M} #eb_main_content,
+      ${M} #bar_mainDiv,
+      ${M} .hwMainListMain {
         flex-wrap: wrap !important;
         width: auto !important;
         max-width: 100% !important;
+        min-width: 0 !important;
+        box-sizing: border-box !important;
       }
 
-      html.ee-mobile-responsive .edubarSidebar,
-      html.ee-mobile-responsive .edubarSidemenu2 {
-        width: auto !important;
+      /* ── Sidebar → collapsed above content ─────────── */
+      ${M} .edubarSidebar,
+      ${M} .edubarSidemenu2 {
+        position: static !important;
+        width: 100% !important;
+        min-width: 0 !important;
+        max-height: none !important;
+        overflow: visible !important;
+        float: none !important;
+      }
+
+      ${M} .edubarSidebar {
+        display: flex !important;
+        flex-wrap: wrap !important;
+        gap: 2px !important;
+        padding: 4px !important;
+      }
+
+      ${M} .edubarMenuitem {
+        flex: 1 1 auto !important;
         min-width: 0 !important;
       }
 
-      html.ee-mobile-responsive table.znamkyTable,
-      html.ee-mobile-responsive .timetable,
-      html.ee-mobile-responsive .gotoDay {
+      ${M} .edubarMenuitem > a {
+        padding: 8px 10px !important;
+        font-size: 13px !important;
+        white-space: nowrap !important;
+        overflow: hidden !important;
+        text-overflow: ellipsis !important;
+      }
+
+      /* ── Top bar compact ────────────────────────────── */
+      ${M} #edubar,
+      ${M} .edubarHeader {
+        flex-wrap: wrap !important;
+        min-height: 0 !important;
+      }
+
+      ${M} .edubarHeaderRight {
+        flex-wrap: wrap !important;
+        gap: 4px !important;
+      }
+
+      ${M} .edubarProfilebox {
+        max-width: 100% !important;
+      }
+
+      ${M} .edubarProfilebox .display {
+        font-size: 13px !important;
+      }
+
+      ${M} #edubarStartButton {
+        padding: 6px 10px !important;
+        font-size: 13px !important;
+      }
+
+      /* ── Main content area full-width ───────────────── */
+      ${M} .skinBody {
+        display: flex !important;
+        flex-direction: column !important;
+        min-width: 0 !important;
+      }
+
+      ${M} .edubarMainNoSkin {
+        display: flex !important;
+        flex-direction: column !important;
+        width: 100% !important;
+      }
+
+      /* ── Dashboard widgets → stack vertically ──────── */
+      ${M} .userTopDiv {
+        flex-direction: column !important;
+      }
+
+      ${M} .userTopDivInner {
+        flex-direction: column !important;
+      }
+
+      ${M} .userButton,
+      ${M} .userHomeWidget,
+      ${M} .userHomeOther {
+        width: 100% !important;
+        max-width: 100% !important;
+        box-sizing: border-box !important;
+        font-size: 13px !important;
+      }
+
+      ${M} .userHomeTitle {
+        font-size: 14px !important;
+      }
+
+      /* ── Timetable strip → full-width, scrollable ──── */
+      ${M} .userRozvrh {
+        flex-direction: column !important;
+      }
+
+      ${M} ul.rozvrh {
+        overflow-x: auto !important;
+        -webkit-overflow-scrolling: touch !important;
+        max-width: 100% !important;
+        padding: 0 !important;
+      }
+
+      ${M} .userStats {
+        flex-wrap: wrap !important;
+        font-size: 12px !important;
+      }
+
+      /* ── Data tables → horizontal scroll ────────────── */
+      ${M} table.znamkyTable,
+      ${M} .timetable,
+      ${M} .gotoDay,
+      ${M} table.dash_dochadzka,
+      ${M} .rozvrhTable,
+      ${M} .grid-container {
         display: block !important;
         overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
         max-width: 100% !important;
       }
 
-      html.ee-mobile-responsive .userButton,
-      html.ee-mobile-responsive .userHomeOther {
+      ${M} table.znamkyTable td,
+      ${M} table.znamkyTable th {
+        padding: 4px 6px !important;
+        font-size: 12px !important;
+      }
+
+      /* ── Timetable cells ────────────────────────────── */
+      ${M} .rozvrhItem,
+      ${M} .rozvrhItemAlign,
+      ${M} .timetable-cell,
+      ${M} .ttItem {
+        min-width: 60px !important;
+        padding: 4px !important;
+        font-size: 11px !important;
+      }
+
+      /* ── Calendar ───────────────────────────────────── */
+      ${M} .userCal2,
+      ${M} .calendar,
+      ${M} .userCalInner {
+        width: 100% !important;
+        max-width: 100% !important;
+        overflow-x: auto !important;
+      }
+
+      /* ── Timeline / news feed ───────────────────────── */
+      ${M} .timeline-container {
+        padding: 0 !important;
+      }
+
+      ${M} .timeline-item,
+      ${M} .tml-item,
+      ${M} .tml-in-reply {
+        padding: 8px !important;
         font-size: 13px !important;
       }
 
-      html.ee-mobile-responsive img,
-      html.ee-mobile-responsive .user-button-icon {
+      /* ── Homework / notifications ───────────────────── */
+      ${M} .hwItem,
+      ${M} .hwItemInner,
+      ${M} .hw-content {
+        padding: 8px !important;
+      }
+
+      ${M} .notifBox {
+        padding: 8px !important;
+        font-size: 13px !important;
+      }
+
+      ${M} .substitution-item {
+        flex-wrap: wrap !important;
+        font-size: 13px !important;
+      }
+
+      /* ── Dialogs / modals → near full-screen ────────── */
+      ${M} .dialog,
+      ${M} .popup,
+      ${M} .modal-content {
+        position: fixed !important;
+        top: 4px !important;
+        left: 4px !important;
+        right: 4px !important;
+        bottom: auto !important;
+        max-width: calc(100vw - 8px) !important;
+        max-height: 90vh !important;
+        overflow-y: auto !important;
+        margin: 0 !important;
+        transform: none !important;
+      }
+
+      ${M} .dropDownPanel,
+      ${M} .dropDown {
+        max-width: calc(100vw - 16px) !important;
+        overflow-x: auto !important;
+      }
+
+      /* ── Buttons / interactive → touch-friendly ─────── */
+      ${M} .smartb,
+      ${M} .flat-button,
+      ${M} button,
+      ${M} .userButton a,
+      ${M} .edubarMenuitem > a {
+        min-height: 44px !important;
+        display: inline-flex !important;
+        align-items: center !important;
+      }
+
+      /* ── Images → fluid ─────────────────────────────── */
+      ${M} img,
+      ${M} .user-button-icon {
         max-width: 100% !important;
         height: auto !important;
+      }
+
+      /* ── Grade filter bar → wrap ────────────────────── */
+      ${M} .zsvHeader,
+      ${M} .zsvFilterElem,
+      ${M} .zsvActionButtonsInner {
+        flex-wrap: wrap !important;
+        gap: 4px !important;
+      }
+
+      ${M} .zsvFilterItem select {
+        min-width: 100px !important;
+        font-size: 13px !important;
+      }
+
+      /* ── Attendance grid ────────────────────────────── */
+      ${M} .attendance-box,
+      ${M} .attendanceItem {
+        min-width: 0 !important;
+        font-size: 12px !important;
+      }
+
+      /* ── Print boxes → stack ────────────────────────── */
+      ${M} .print-box {
+        width: 100% !important;
+        max-width: 100% !important;
+      }
+
+      /* ── Logo area compact ──────────────────────────── */
+      ${M} .userTopLogo {
+        padding: 8px !important;
+        font-size: 14px !important;
+      }
+
+      ${M} .userTopLogo img {
+        max-height: 32px !important;
+        width: auto !important;
+      }
+
+      /* ── Ribbon (toolbar) → wrap ────────────────────── */
+      ${M} .edubarRibbon,
+      ${M} .ribbon-section {
+        flex-wrap: wrap !important;
+        gap: 2px !important;
+      }
+
+      ${M} .ribbon-button {
+        padding: 6px 8px !important;
+        font-size: 12px !important;
+      }
+
+      /* ── Profile menu dropdown ──────────────────────── */
+      ${M} .profilemenu {
+        max-width: calc(100vw - 16px) !important;
+      }
+
+      ${M} .profilemenu li,
+      ${M} .profilemenu a {
+        padding: 10px 12px !important;
+        font-size: 14px !important;
+      }
+
+      /* ── Gadget boxes → full width ──────────────────── */
+      ${M} .gadgetBox {
+        width: 100% !important;
+        max-width: 100% !important;
+        box-sizing: border-box !important;
+      }
+
+      /* ── Scrollbar hide on touch (thin on desktop) ──── */
+      ${M} ::-webkit-scrollbar {
+        width: 4px !important;
+        height: 4px !important;
+      }
+    }
+
+    @media (max-width: 480px) {
+      ${M} .edubarSidebar {
+        gap: 1px !important;
+        padding: 2px !important;
+      }
+
+      ${M} .edubarMenuitem > a {
+        padding: 6px 6px !important;
+        font-size: 11px !important;
+      }
+
+      ${M} .userButton,
+      ${M} .userHomeOther,
+      ${M} .timeline-item,
+      ${M} .tml-item,
+      ${M} .hwItem,
+      ${M} .notifBox {
+        padding: 6px !important;
+        font-size: 12px !important;
+      }
+
+      ${M} table.znamkyTable td,
+      ${M} table.znamkyTable th {
+        padding: 3px 4px !important;
+        font-size: 11px !important;
+      }
+
+      ${M} .rozvrhItem,
+      ${M} .timetable-cell,
+      ${M} .ttItem {
+        min-width: 50px !important;
+        font-size: 10px !important;
       }
     }
   `;

--- a/scripts/grades-enhancer.js
+++ b/scripts/grades-enhancer.js
@@ -1209,12 +1209,8 @@
   function dispatchSyntheticClick(element) {
     if (!element) return false;
     try {
-      if (typeof element.click === "function") {
-        element.click();
-      }
-      // Also dispatch a bubbling MouseEvent because EduPage often attaches
-      // its toggle handlers via jQuery delegation higher up the tree —
-      // direct .click() doesn't always traverse the delegation chain.
+      // Use a bubbling MouseEvent so jQuery delegation handlers higher up
+      // the tree also fire (direct .click() doesn't always reach them).
       element.dispatchEvent(new MouseEvent("click", {
         bubbles: true,
         cancelable: true,

--- a/scripts/instant-theme.css
+++ b/scripts/instant-theme.css
@@ -1,10 +1,10 @@
 html.ee-dark {
   color-scheme: dark !important;
-  background: #11111b !important;
+  background: #0c1220 !important;
 }
 
 html.ee-dark body {
-  background: #11111b !important;
+  background: #0c1220 !important;
   color: #cdd6f4 !important;
 }
 
@@ -14,7 +14,7 @@ html.ee-dark .skinContent,
 html.ee-dark .userContentInner,
 html.ee-dark #eb_main_content,
 html.ee-dark #bar_mainDiv {
-  background: #11111b !important;
+  background: #0c1220 !important;
   color: #cdd6f4 !important;
 }
 
@@ -86,6 +86,6 @@ html.ee-theme-custom .skinContent,
 html.ee-theme-custom .userContentInner,
 html.ee-theme-custom #eb_main_content,
 html.ee-theme-custom #bar_mainDiv {
-  background: var(--ee-custom-bg-base, #11111b) !important;
+  background: var(--ee-custom-bg-base, #0c1220) !important;
   color: var(--ee-custom-text-main, #cdd6f4) !important;
 }

--- a/scripts/timetable-enhancer.js
+++ b/scripts/timetable-enhancer.js
@@ -149,7 +149,7 @@
 
   // "... Zameniť učebňu: OLD ➔ NEW ..." — returns the new room code/name.
   function extractNewRoom(info) {
-    const match = /Zameni[ťt]\s*u[čc]ebňu:?\s*[^➔→⇒→➔]+[➔→⇒→➔]\s*([^\s,;(]+)/i
+    const match = /Zameni[ťt]\s*u[čc]ebňu:?\s*[^➔→⇒]+[➔→⇒]\s*([^\s,;(]+)/i
       .exec(String(info || ""));
     return match ? match[1].trim() : null;
   }
@@ -189,8 +189,11 @@
   // every authenticated page. Content scripts can't read the page's JS globals
   // directly, but the assignment is in the page HTML, so scrape it from there.
   function getGsecHash() {
-    const match = /gsechash["'\s:=]+([A-Za-z0-9]{6,})/.exec(document.documentElement.innerHTML);
-    return match ? match[1] : null;
+    for (const script of document.querySelectorAll("script:not([src])")) {
+      const match = /gsechash["'\s:=]+([A-Za-z0-9]{6,})/.exec(script.textContent);
+      if (match) return match[1];
+    }
+    return null;
   }
 
   // The Suplovanie page is fully client-rendered, but its viewer.js POST returns
@@ -514,8 +517,8 @@
   function scheduleRozvrhEnhance() {
     window.clearTimeout(rozvrhScheduleTimer);
     rozvrhScheduleTimer = window.setTimeout(() => {
-      enhanceRozvrhWidget();
-      enhanceRozvrhRooms();
+      enhanceRozvrhWidget().catch(() => {});
+      enhanceRozvrhRooms().catch(() => {});
     }, 200);
   }
 
@@ -584,8 +587,8 @@
   function initStorage() {
     chrome.storage.local.get([HIGHLIGHTS_KEY], (result) => {
       highlightsEnabled = result[HIGHLIGHTS_KEY] !== false;
-      if (highlightsEnabled) enhanceRozvrhWidget();
-      enhanceRozvrhRooms(); // independent of the highlights toggle — a display preference, not a highlight
+      if (highlightsEnabled) enhanceRozvrhWidget().catch(() => {});
+      enhanceRozvrhRooms().catch(() => {});
     });
 
     chrome.storage.onChanged.addListener((changes, area) => {
@@ -607,13 +610,13 @@
 
     if (document.readyState === "loading") {
       document.addEventListener("DOMContentLoaded", () => {
-        enhanceRozvrhWidget();
-        enhanceRozvrhRooms();
+        enhanceRozvrhWidget().catch(() => {});
+        enhanceRozvrhRooms().catch(() => {});
         initRozvrhObserver();
       }, { once: true });
     } else {
-      enhanceRozvrhWidget();
-      enhanceRozvrhRooms();
+      enhanceRozvrhWidget().catch(() => {});
+      enhanceRozvrhRooms().catch(() => {});
       initRozvrhObserver();
     }
   }

--- a/scripts/timetable-sync.js
+++ b/scripts/timetable-sync.js
@@ -2,6 +2,8 @@
   "use strict";
 
   if (window.top !== window) return;
+  if (window.__eeTimetableSyncInit) return;
+  window.__eeTimetableSyncInit = true;
 
   const DAY_MS = 24 * 60 * 60 * 1000;
   let lastResolvedWeekStart = null;
@@ -339,10 +341,12 @@
   }
 
   async function clickWeekNavigator(direction) {
-    const targetText = direction > 0 ? ">>" : "<<";
-    const control = Array.from(document.querySelectorAll("span")).find((element) => element.textContent.trim() === targetText);
+    const forwardTexts = [">>", "»", "»", "››"];
+    const backwardTexts = ["<<", "«", "«", "‹‹"];
+    const candidates = direction > 0 ? forwardTexts : backwardTexts;
+    const control = Array.from(document.querySelectorAll("span")).find((element) => candidates.includes(element.textContent.trim()));
     if (!control) {
-      throw new Error(`Could not find timetable navigation control: ${targetText}`);
+      throw new Error(`Could not find timetable navigation control: ${candidates[0]}`);
     }
 
     const before = readWeekSignature();
@@ -393,6 +397,8 @@
     if (message?.type !== "ee-extract-timetable-week" && message?.type !== "ee-extract-timetable-week-series") return false;
 
     (async () => {
+      lastResolvedWeekStart = null;
+
       if (!window.location.href.includes("mode=timetable")) {
         throw new Error("The hidden tab is not on the EduPage timetable page.");
       }


### PR DESCRIPTION
## What's new

### Mobile-Responsive Layout
- Expanded responsive CSS from ~40 lines to ~300 lines covering every major EduPage UI component
- Sidebar collapses into a horizontal flex-wrap nav bar on small screens
- All fixed-width containers become fluid, dashboard widgets stack vertically
- Data tables (grades, timetable, attendance) get horizontal scroll with touch momentum
- Dialogs/modals resize to near-fullscreen, interactive elements get 44px minimum touch targets
- Added 480px breakpoint for extra-small phones with tighter spacing
- Moved toggle from Debug tab to Cleanup tab alongside other layout settings

### Auto-Login
- New `autologin.js` that detects browser autofill on `/login` pages and auto-submits the form when both username and password fields are populated
- Polls for autofill completion with a MutationObserver fallback for dynamically-rendered forms
- Shows a brief status badge with fade-out, 10-second timeout, off by default
- No credentials stored — relies entirely on the browser's own password manager
- Toggle in Features tab, localized for en/sk/cs

## Bug fixes
- Fix popup storage key mismatch (missing `ee` prefix) that silently reset mobile responsive mode and lost timetable highlight colors on every popup toggle
- Fix FOUC dark mode flash — aligned `instant-theme.css` background from `#11111b` to `#0c1220` to match content.js palette
- Fix double-fire synthetic click in grades enhancer (`.click()` + `dispatchEvent()` was toggling handlers twice)
- Fix `getGsecHash()` serializing the entire DOM via `innerHTML` — now iterates only `<script>` tags
- Fix timetable week navigation only matching ASCII `>>` / `<<` — now also accepts `»`, `«`, `››`, `‹‹`
- Add re-injection guard and stale week-start reset in timetable-sync
- Fix notification icon referencing nonexistent `placeholder_icon.png`
- Add `.catch(() => {})` to 6 fire-and-forget async calls in timetable-enhancer
- Remove redundant synchronous `enhanceAttendanceTable()` call in attendance-enhancer init
- Sync activity shield indicator `aria-label` with its dynamic `title`
- Add `prefers-reduced-motion` blanket rule to settings page CSS

## Test plan
- [x] All 7 test suites pass (43 assertions, 0 failures)
- [ ] Toggle dark mode from popup — verify no white flash (FOUC fix)
- [ ] Toggle dark mode from popup with mobile responsive enabled — verify it stays on
- [ ] Open timetable page — verify week navigation arrows still work
- [ ] Open grades page — verify clicking grade rows toggles correctly (no double-fire)
- [ ] Load extension on a phone or narrow viewport — verify responsive layout
- [ ] Enable auto-login, visit login page with saved credentials — verify auto-submit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Auto-Login option with localized toggle text and a submitting status indicator.
  * Enhanced mobile responsiveness with a dedicated layout option and more complete compact layout behavior.
* **Bug Fixes**
  * Improved reliability of timetable, grades, and attendance enhancements and reduced chances of unhandled errors.
  * Hardened timetable parsing/sync logic and improved keyboard/screen-reader labeling.
* **Style**
  * Reduced motion support: animations and transitions are minimized when requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->