### PR TITLE
Rework popup & settings UI, improve mobile-responsive EduPage CSS

### DIFF
--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -3,6 +3,7 @@
   "extDescription": { "message": "Doplňky kvality života pro Edupage – motivy, nástroje na známky, statistiky docházky a export rozvrhu." },
 
   "madeBy": { "message": "Vytvořil" },
+  "madeByContributors": { "message": "a přispěvatelé" },
   "openGithub": { "message": "Otevřít GitHub" },
   "openShortcutSettings": { "message": "Otevřít nastavení zkratek" },
   "noHotkey": { "message": "Žádná zkratka není přiřazena." },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3,6 +3,7 @@
   "extDescription": { "message": "QoL extras for Edupage - themes, grade tools, attendance stats, and timetable export." },
 
   "madeBy": { "message": "Made by" },
+  "madeByContributors": { "message": "and contributors" },
   "openGithub": { "message": "Open GitHub" },
   "openShortcutSettings": { "message": "Open Shortcut Settings" },
   "noHotkey": { "message": "No hotkey assigned." },

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -3,6 +3,7 @@
   "extDescription": { "message": "Doplnky kvality života pre Edupage – témy, nástroje na známky, štatistiky dochádzky a export rozvrhu." },
 
   "madeBy": { "message": "Vytvoril" },
+  "madeByContributors": { "message": "a prispievatelia" },
   "openGithub": { "message": "Otvoriť GitHub" },
   "openShortcutSettings": { "message": "Otvoriť nastavenia skratiek" },
   "noHotkey": { "message": "Žiadna skratka nie je priradená." },

--- a/menu/menu.css
+++ b/menu/menu.css
@@ -3,6 +3,8 @@
 }
 
 :root {
+    /* Match native controls (scrollbars, focus halos) to the theme. */
+    color-scheme: dark;
     --page-bg: #11111b;
     --surface-bg: #181825;
     --control-bg: #1e1e2e;
@@ -11,12 +13,23 @@
     --text-muted: #a6adc8;
     --accent-color: #89b4fa;
 
-    --radius-outer: 10px;
-    --radius-inner: 8px;
+    /* Derived tints — recomputed per theme from the vars above, so every
+       theme (including custom) tints the chrome without extra definitions. */
+    --accent-soft: color-mix(in srgb, var(--accent-color) 16%, transparent);
+    --accent-faint: color-mix(in srgb, var(--accent-color) 9%, transparent);
+    --border-subtle: color-mix(in srgb, var(--border-color) 72%, transparent);
+
+    --radius-outer: 12px;
+    --radius-inner: 9px;
     --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
     --shadow-raised:
         0 1px 2px rgba(0, 0, 0, 0.16),
         0 2px 6px rgba(0, 0, 0, 0.12);
+}
+
+:root[data-theme="light"],
+:root[data-theme="pink"] {
+    color-scheme: light;
 }
 
 :root[data-theme="ocean"] {
@@ -103,53 +116,109 @@ body {
 }
 
 body {
-    font-family: -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    font-family: "Segoe UI Variable Text", "Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
 }
 
 .menu {
     display: flex;
     flex-direction: column;
-    width: 288px;
-    min-height: 188px;
+    position: relative;
+    width: 324px;
+    max-width: 100vw;
+    min-height: 200px;
+    margin: 0 auto;
     padding: 16px;
+    overflow: hidden;
+}
+
+/* Theme-reactive glow behind the header — picks up whichever accent the
+   active theme (or the user's custom palette) defines. */
+.menu::before {
+    content: "";
+    position: absolute;
+    top: -70px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 260px;
+    height: 150px;
+    background: radial-gradient(closest-side, var(--accent-soft), transparent);
+    pointer-events: none;
+}
+
+.menu > * {
+    position: relative;
 }
 
 .menu-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: 12px;
     margin-bottom: 16px;
 }
 
+.menu-logo {
+    flex: 0 0 auto;
+    border-radius: 10px;
+}
+
+.menu-heading {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+}
+
 h1 {
     margin: 0;
+    font-family: "Segoe UI Variable Display", "Segoe UI", system-ui, sans-serif;
     font-size: 16px;
-    font-weight: 700;
-    letter-spacing: -0.01em;
+    font-weight: 800;
+    letter-spacing: -0.015em;
 }
 
 .menu-version {
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-inner);
+    align-self: flex-start;
+    border: 1px solid var(--border-subtle);
+    border-radius: 999px;
+    background: var(--surface-bg);
     color: var(--text-muted);
-    font-size: 11px;
+    font-size: 10.5px;
+    font-weight: 600;
     font-variant-numeric: tabular-nums;
-    padding: 3px 7px;
+    padding: 1px 8px;
+}
+
+.menu-version:not(:empty)::before {
+    content: "v";
+}
+
+.row-chip {
+    display: grid;
+    place-items: center;
+    flex: 0 0 auto;
+    width: 32px;
+    height: 32px;
+    border-radius: 9px;
+    background: var(--accent-soft);
+    color: var(--accent-color);
+}
+
+.row-chip svg {
+    width: 17px;
+    height: 17px;
 }
 
 .toggle-row {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: 12px;
-    border: 1px solid var(--border-color);
+    border: 1px solid var(--border-subtle);
     border-radius: var(--radius-outer);
     background: var(--surface-bg);
     box-shadow: var(--shadow-raised);
     cursor: pointer;
-    margin-bottom: 12px;
-    padding: 10px 12px;
+    margin-bottom: 10px;
+    padding: 11px 12px;
     transition: border-color 150ms var(--ease-out), transform 150ms var(--ease-out);
 }
 
@@ -162,6 +231,7 @@ h1 {
 }
 
 .toggle-row-copy {
+    flex: 1;
     min-width: 0;
 }
 
@@ -172,13 +242,13 @@ h1 {
 
 .toggle-row strong {
     font-size: 13px;
-    font-weight: 600;
+    font-weight: 650;
 }
 
 .toggle-row small {
     color: var(--text-muted);
-    font-size: 11px;
-    margin-top: 3px;
+    font-size: 11.5px;
+    margin-top: 2px;
 }
 
 .switch {
@@ -190,33 +260,32 @@ h1 {
 
 .switch-compact {
     justify-content: flex-end;
-    min-width: 52px;
+    min-width: 44px;
 }
 
 .switch-track {
-    background: #5b6470;
-    border: 1px solid #7b8592;
+    background: color-mix(in srgb, var(--text-muted) 38%, transparent);
+    border: 1px solid transparent;
     border-radius: 999px;
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
     display: inline-flex;
     flex: 0 0 auto;
-    height: 28px;
+    height: 26px;
     position: relative;
-    transition: background-color 150ms var(--ease-out), border-color 150ms var(--ease-out), box-shadow 150ms var(--ease-out);
-    width: 48px;
+    transition: background-color 180ms var(--ease-out);
+    width: 44px;
 }
 
 .switch-track::after {
     background: #ffffff;
     border-radius: 50%;
-    box-shadow: 0 1px 3px rgba(15, 23, 42, 0.3);
+    box-shadow: 0 1px 3px rgba(15, 23, 42, 0.35);
     content: "";
-    height: 22px;
+    height: 20px;
     left: 2px;
     position: absolute;
     top: 2px;
-    transition: transform 150ms var(--ease-out);
-    width: 22px;
+    transition: transform 180ms var(--ease-out);
+    width: 20px;
 }
 
 .sr-only {
@@ -240,12 +309,11 @@ h1 {
 }
 
 .switch input[type="checkbox"]:checked + .switch-track {
-    background: #34c759;
-    border-color: #34c759;
+    background: var(--accent-color);
 }
 
 .switch input[type="checkbox"]:checked + .switch-track::after {
-    transform: translateX(20px);
+    transform: translateX(18px);
 }
 
 .switch input[type="checkbox"]:focus-visible + .switch-track {
@@ -260,12 +328,11 @@ h1 {
 
 .update-notice {
     display: grid;
-    gap: 8px;
-    border: 1px solid var(--accent-color);
+    gap: 10px;
+    border: 1px solid color-mix(in srgb, var(--accent-color) 45%, transparent);
     border-radius: var(--radius-outer);
-    background: var(--surface-bg);
-    box-shadow: var(--shadow-raised);
-    margin-top: 12px;
+    background: var(--accent-faint);
+    margin: 2px 0 14px;
     padding: 12px;
     animation: noticeIn 200ms var(--ease-out) both;
 }
@@ -298,31 +365,43 @@ h1 {
 
 .update-notice small {
     color: var(--text-muted);
-    font-size: 11px;
-    line-height: 1.4;
+    font-size: 11.5px;
+    line-height: 1.45;
+    margin-top: 2px;
 }
 
 .menu-button {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    gap: 12px;
     width: 100%;
-    border: 1px solid var(--border-color);
+    border: 1px solid var(--border-subtle);
     border-radius: var(--radius-outer);
-    background: var(--control-bg);
+    background: var(--surface-bg);
+    box-shadow: var(--shadow-raised);
     color: var(--text-main);
     cursor: pointer;
     font: inherit;
-    font-weight: 600;
-    padding: 10px 12px;
+    font-size: 13px;
+    font-weight: 650;
+    padding: 11px 12px;
     text-align: left;
-    transition: border-color 150ms var(--ease-out), color 150ms var(--ease-out), transform 100ms var(--ease-out);
+    transition: border-color 150ms var(--ease-out), transform 100ms var(--ease-out);
+}
+
+.update-notice .menu-button {
+    background: var(--control-bg);
+    box-shadow: none;
+}
+
+.menu-button-label {
+    flex: 1;
+    min-width: 0;
 }
 
 .menu-button:hover,
 .menu-button:focus-visible {
     border-color: var(--accent-color);
-    color: var(--accent-color);
     outline: none;
 }
 
@@ -335,24 +414,31 @@ h1 {
     transform: scale(0.98);
 }
 
-.menu-button span[aria-hidden] {
+.menu-chevron {
+    width: 16px;
+    height: 16px;
+    flex: 0 0 auto;
     color: var(--text-muted);
-    transition: transform 150ms var(--ease-out);
+    transition: transform 150ms var(--ease-out), color 150ms var(--ease-out);
 }
 
-.menu-button:hover span[aria-hidden],
-.menu-button:focus-visible span[aria-hidden] {
+.menu-button:hover .menu-chevron,
+.menu-button:focus-visible .menu-chevron {
     transform: translateX(2px);
     color: var(--accent-color);
 }
 
 .made-by {
-    border-top: 1px solid var(--border-color);
+    border-top: 1px solid var(--border-subtle);
     color: var(--text-muted);
     font-size: 12px;
     margin-top: auto;
     padding-top: 12px;
     text-align: center;
+}
+
+.button-stack {
+    margin-bottom: 14px;
 }
 
 .made-by a {
@@ -366,6 +452,11 @@ h1 {
 .made-by a:focus-visible {
     text-decoration: underline;
     outline: none;
+}
+
+.made-by a.made-by-contributors {
+    color: var(--text-muted);
+    font-weight: 600;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/menu/menu.html
+++ b/menu/menu.html
@@ -9,11 +9,17 @@
   <body>
     <main class="menu">
       <header class="menu-header">
-        <h1 data-i18n="extName">Edupage Extras</h1>
-        <span class="menu-version" id="MenuVersion"></span>
+        <img class="menu-logo" src="../images/icon-48.png" alt="" width="38" height="38">
+        <div class="menu-heading">
+          <h1 data-i18n="extName">Edupage Extras</h1>
+          <span class="menu-version" id="MenuVersion"></span>
+        </div>
       </header>
 
       <label class="toggle-row" for="DarkModeCheckbox">
+        <span class="row-chip" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+        </span>
         <span class="toggle-row-copy">
           <strong data-i18n="themesLabel">Themes</strong>
           <small data-i18n="menuThemesHint">Use Edupage Extras colors</small>
@@ -27,22 +33,27 @@
 
       <div class="button-stack">
         <button class="menu-button" id="SettingsButton" type="button">
-          <span data-i18n="settingsButton">Settings</span>
-          <span aria-hidden="true">></span>
+          <span class="row-chip" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h2m4 0h10M4 12h8m4 0h4M4 18h5m4 0h7"/><circle cx="8" cy="6" r="2"/><circle cx="14" cy="12" r="2"/><circle cx="11" cy="18" r="2"/></svg>
+          </span>
+          <span class="menu-button-label" data-i18n="settingsButton">Settings</span>
+          <svg class="menu-chevron" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
         </button>
       </div>
 
       <section class="update-notice" id="UpdateNotice" hidden>
-        <strong data-i18n="updateAvailableTitle">Update available</strong>
-        <small id="UpdateNoticeText" data-i18n="menuUpdateHint">Pull the latest project from GitHub.</small>
+        <div class="update-notice-copy">
+          <strong data-i18n="updateAvailableTitle">Update available</strong>
+          <small id="UpdateNoticeText" data-i18n="menuUpdateHint">Pull the latest project from GitHub.</small>
+        </div>
         <button class="menu-button" id="OpenUpdateButton" type="button">
-          <span data-i18n="openGithub">Open GitHub</span>
-          <span aria-hidden="true">></span>
+          <span class="menu-button-label" data-i18n="openGithub">Open GitHub</span>
+          <svg class="menu-chevron" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
         </button>
       </section>
 
       <footer class="made-by">
-        <span data-i18n="madeBy">Made by</span> <a href="https://github.com/Alexosavrua" target="_blank" rel="noopener noreferrer">JustAlex</a>
+        <span data-i18n="madeBy">Made by</span> <a href="https://github.com/Alexosavrua" target="_blank" rel="noopener noreferrer">JustAlex</a> <a class="made-by-contributors" href="https://github.com/Alexosavrua/Edupage-Extras/graphs/contributors" target="_blank" rel="noopener noreferrer" data-i18n="madeByContributors">and contributors</a>
       </footer>
     </main>
     <script src="i18n.js"></script>

--- a/menu/settings.css
+++ b/menu/settings.css
@@ -15,6 +15,20 @@
     --text-muted: #a6adc8;
     --accent-color: #89b4fa;
     --danger-color: #f38ba8;
+
+    /* Derived tints — recomputed per theme from the vars above, so every
+       theme (including custom) re-tints the whole page without extra blocks. */
+    --accent-soft: color-mix(in srgb, var(--accent-color) 16%, transparent);
+    --accent-faint: color-mix(in srgb, var(--accent-color) 9%, transparent);
+    --danger-soft: color-mix(in srgb, var(--danger-color) 9%, transparent);
+    --border-subtle: color-mix(in srgb, var(--border-color) 72%, transparent);
+
+    --radius-card: 14px;
+    --radius-control: 9px;
+    --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+    --shadow-raised:
+        0 1px 2px rgba(0, 0, 0, 0.14),
+        0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 :root[data-theme="light"],
@@ -97,6 +111,13 @@
     --text-muted: #596273;
     --accent-color: #246bca;
     --danger-color: #d7113f;
+    --shadow-raised:
+        0 1px 2px rgba(20, 30, 50, 0.05),
+        0 2px 10px rgba(20, 30, 50, 0.05);
+}
+
+html {
+    scrollbar-color: var(--border-color) transparent;
 }
 
 html,
@@ -111,16 +132,33 @@ body {
 
 body {
     min-height: 100vh;
-    font-family: -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    font-family: "Segoe UI Variable Text", "Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
+    font-size: 14px;
+}
+
+/* Theme-reactive glow behind the page header — follows the active accent. */
+body::before {
+    content: "";
+    position: fixed;
+    top: -160px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(860px, 92vw);
+    height: 300px;
+    background: radial-gradient(closest-side, var(--accent-faint), transparent);
+    pointer-events: none;
+    z-index: 0;
 }
 
 .settings {
     display: flex;
     flex-direction: column;
-    max-width: 920px;
+    position: relative;
+    z-index: 1;
+    max-width: 960px;
     min-height: 100vh;
     margin: 0 auto;
-    padding: 32px 18px;
+    padding: 36px 24px 24px;
 }
 
 .page-header {
@@ -128,37 +166,49 @@ body {
     align-items: flex-start;
     justify-content: space-between;
     gap: 16px;
-    margin-bottom: 22px;
+    margin-bottom: 26px;
 }
 
 .settings-body {
     display: flex;
-    align-items: stretch;
-    gap: 24px;
+    align-items: flex-start;
+    gap: 32px;
     flex: 1;
+    width: 100%;
 }
 
 .settings-nav {
     display: flex;
     flex-direction: column;
-    gap: 2px;
-    flex: 0 0 180px;
+    gap: 3px;
+    flex: 0 0 204px;
     position: sticky;
-    top: 32px;
+    top: 28px;
 }
 
 .settings-nav-item {
-    border: 1px solid transparent;
-    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    position: relative;
+    border: none;
+    border-radius: var(--radius-control);
     background: transparent;
     color: var(--text-muted);
     cursor: pointer;
     font: inherit;
     font-weight: 600;
-    font-size: 14px;
-    padding: 10px 12px;
+    font-size: 13.5px;
+    padding: 9px 13px;
     text-align: left;
-    transition: background-color 150ms cubic-bezier(0.23, 1, 0.32, 1), color 150ms cubic-bezier(0.23, 1, 0.32, 1);
+    transition: background-color 150ms var(--ease-out), color 150ms var(--ease-out);
+}
+
+.nav-icon {
+    width: 17px;
+    height: 17px;
+    flex: 0 0 auto;
+    opacity: 0.9;
 }
 
 .settings-nav-item:hover {
@@ -167,8 +217,19 @@ body {
 }
 
 .settings-nav-item[aria-selected="true"] {
-    background: var(--control-bg);
+    background: var(--accent-soft);
     color: var(--accent-color);
+}
+
+.settings-nav-item[aria-selected="true"]::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 9px;
+    bottom: 9px;
+    width: 3px;
+    border-radius: 3px;
+    background: var(--accent-color);
 }
 
 .settings-nav-item:focus-visible {
@@ -176,79 +237,26 @@ body {
     outline-offset: 2px;
 }
 
+.settings-nav-item-experimental {
+    margin-top: 14px;
+}
+
+.settings-nav-item-experimental::after {
+    content: "";
+    position: absolute;
+    top: -8px;
+    left: 13px;
+    right: 13px;
+    height: 1px;
+    background: var(--border-subtle);
+}
+
 .settings-content {
     flex: 1;
     min-width: 0;
 }
 
-.settings-nav-item-experimental {
-    margin-top: auto;
-    color: var(--text-muted);
-    border-top: 1px solid var(--border-color);
-    border-radius: 0;
-    padding-top: 14px;
-}
-
-.settings-nav-item-experimental[aria-selected="true"] {
-    background: transparent;
-    color: var(--text-muted);
-}
-
-.confirm-dialog {
-    max-width: 360px;
-    border: 1px solid var(--border-color);
-    border-radius: 12px;
-    background: var(--surface-bg);
-    color: var(--text-main);
-    box-shadow:
-        0 4px 12px rgba(0, 0, 0, 0.18),
-        0 12px 32px rgba(0, 0, 0, 0.16);
-    padding: 20px;
-}
-
-.confirm-dialog[open] {
-    animation: confirmDialogIn 200ms cubic-bezier(0.23, 1, 0.32, 1) both;
-}
-
-@keyframes confirmDialogIn {
-    from {
-        opacity: 0;
-        transform: scale(0.96);
-    }
-    to {
-        opacity: 1;
-        transform: scale(1);
-    }
-}
-
-.confirm-dialog::backdrop {
-    background: rgba(0, 0, 0, 0.45);
-}
-
-.confirm-dialog h2 {
-    font-size: 16px;
-    margin-bottom: 8px;
-}
-
-.confirm-dialog p {
-    margin-top: 0;
-}
-
-.confirm-dialog-actions {
-    justify-content: flex-end;
-    margin-top: 16px;
-}
-
-.confirm-dialog-confirm {
-    border-color: var(--danger-color);
-    color: var(--danger-color);
-}
-
-.confirm-dialog-confirm:hover,
-.confirm-dialog-confirm:focus-visible {
-    background: var(--danger-color);
-    color: var(--surface-bg);
-}
+/* ---- Type ------------------------------------------------------------- */
 
 h1,
 h2,
@@ -258,19 +266,23 @@ p {
 }
 
 h1 {
-    font-size: 28px;
+    font-family: "Segoe UI Variable Display", "Segoe UI", system-ui, sans-serif;
+    font-size: 26px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
 }
 
 h2 {
-    color: var(--accent-color);
-    font-size: 13px;
-    letter-spacing: 0;
-    margin-bottom: 10px;
-    text-transform: uppercase;
+    font-family: "Segoe UI Variable Display", "Segoe UI", system-ui, sans-serif;
+    font-size: 19px;
+    font-weight: 800;
+    letter-spacing: -0.01em;
+    margin-bottom: 14px;
 }
 
 h3 {
-    font-size: 16px;
+    font-size: 14px;
+    font-weight: 650;
     margin: 0;
 }
 
@@ -281,16 +293,94 @@ h4 {
 
 p {
     color: var(--text-muted);
-    line-height: 1.5;
+    font-size: 13px;
+    line-height: 1.55;
+    margin-top: 4px;
+}
+
+.page-header p {
+    font-size: 14px;
     margin-top: 6px;
 }
 
-.section-heading {
-    margin-bottom: 12px;
+.setting-group-subtitle {
+    margin: -8px 0 14px;
 }
 
-.prominent-row {
-    border-color: var(--accent-color);
+.section-heading {
+    margin: 24px 2px 10px;
+}
+
+.section-heading h3 {
+    color: var(--accent-color);
+    font-size: 11.5px;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+}
+
+.inline-link {
+    color: var(--accent-color);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.inline-link:hover,
+.inline-link:focus-visible {
+    text-decoration: underline;
+    outline: none;
+}
+
+code {
+    background: var(--control-bg);
+    border-radius: 5px;
+    font-family: ui-monospace, SFMono-Regular, Consolas, Menlo, monospace;
+    font-size: 0.92em;
+    padding: 1px 5px;
+}
+
+[hidden] {
+    display: none !important;
+}
+
+/* ---- Panels & cards ---------------------------------------------------- */
+
+.setting-group {
+    margin-bottom: 26px;
+}
+
+.setting-group:not([hidden]) {
+    animation: panelIn 220ms var(--ease-out) both;
+}
+
+@keyframes panelIn {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.setting-group:focus-visible {
+    border-radius: var(--radius-control);
+    outline: 2px solid var(--accent-soft);
+    outline-offset: 4px;
+}
+
+.setting-card {
+    background: var(--surface-bg);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-card);
+    box-shadow: var(--shadow-raised);
+    margin-bottom: 14px;
+    overflow: hidden;
+}
+
+.setting-card > :not([hidden]) ~ :not([hidden]) {
+    border-top: 1px solid var(--border-subtle);
 }
 
 .setting-row {
@@ -298,11 +388,7 @@ p {
     align-items: center;
     justify-content: space-between;
     gap: 20px;
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    background: var(--surface-bg);
-    margin-bottom: 12px;
-    padding: 16px;
+    padding: 15px 18px;
 }
 
 /* Let the description column shrink (text wraps) so wide controls like the
@@ -311,39 +397,69 @@ p {
     min-width: 0;
 }
 
-[hidden] {
-    display: none !important;
+.setting-row p {
+    max-width: 58ch;
 }
 
-.setting-group {
-    margin-bottom: 22px;
+.setting-row-stack {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 12px;
 }
+
+.custom-theme-row {
+    align-items: flex-start;
+}
+
+.prominent-row {
+    background: var(--accent-faint);
+}
+
+/* ---- Notes, tags, hints ------------------------------------------------ */
 
 .setting-note {
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    background: var(--surface-bg);
-    margin-bottom: 12px;
-    padding: 14px 16px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--control-bg) 65%, transparent);
+    color: var(--text-muted);
+    font-size: 13px;
+    line-height: 1.55;
+    margin: 0;
+    padding: 12px 14px;
+}
+
+.setting-note:empty {
+    display: none;
 }
 
 .setting-note strong {
+    color: var(--text-main);
     display: block;
     font-size: 13px;
+    margin-bottom: 2px;
 }
 
 .setting-note-warning {
-    border-color: var(--danger-color);
+    background: var(--danger-soft);
+    border-color: color-mix(in srgb, var(--danger-color) 35%, transparent);
 }
 
 .setting-note-warning strong {
     color: var(--danger-color);
 }
 
+/* Notes placed directly inside a card become full-width strips separated by
+   the card's own dividers. */
+.setting-card > .setting-note {
+    border: 0;
+    border-radius: 0;
+    padding: 14px 18px;
+}
+
 /* A one-line hint, lighter than .setting-note — no border/background box, just
    muted text. For tips that don't need the visual weight of a full note. */
 .setting-tip {
-    margin: 4px 0 0;
+    margin: 2px 4px 0;
     font-size: 12px;
     color: var(--text-muted);
 }
@@ -352,13 +468,13 @@ p {
     display: inline-block;
     vertical-align: middle;
     margin-left: 8px;
-    padding: 2px 6px;
-    border-radius: 4px;
+    padding: 2px 7px;
+    border-radius: 999px;
     font-size: 10px;
     font-weight: 700;
     letter-spacing: 0.5px;
     text-transform: uppercase;
-    line-height: 1.2;
+    line-height: 1.3;
 }
 
 .setting-tag-wip {
@@ -373,14 +489,7 @@ p {
     color: var(--text-muted);
 }
 
-.setting-row-stack {
-    align-items: stretch;
-    flex-direction: column;
-}
-
-.custom-theme-row {
-    align-items: flex-start;
-}
+/* ---- Custom theme editor ----------------------------------------------- */
 
 .custom-theme-controls {
     display: grid;
@@ -400,12 +509,12 @@ p {
     align-items: center;
     justify-content: space-between;
     gap: 10px;
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-control);
     background: var(--control-bg);
     color: var(--text-muted);
-    font-size: 13px;
-    padding: 8px 10px;
+    font-size: 12.5px;
+    padding: 7px 8px 7px 11px;
 }
 
 .custom-theme-import {
@@ -420,22 +529,20 @@ p {
     width: 100%;
     min-height: 104px;
     resize: vertical;
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-control);
     background: var(--control-bg);
     color: var(--text-main);
-    font: 12px/1.45 Consolas, "Courier New", monospace;
+    font: 12px/1.45 ui-monospace, SFMono-Regular, Consolas, "Courier New", monospace;
     padding: 9px 10px;
 }
 
-.custom-theme-import textarea:focus-visible {
-    border-color: var(--accent-color);
-    outline: none;
-}
+/* ---- Control clusters --------------------------------------------------- */
 
 .actions-row {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 10px;
 }
 
@@ -451,14 +558,20 @@ p {
     color: var(--text-main);
     cursor: pointer;
     display: inline-flex;
-    font-size: 14px;
+    font-size: 13.5px;
     gap: 8px;
+}
+
+.inline-checkbox input[type="checkbox"] {
+    accent-color: var(--accent-color);
+    height: 16px;
+    width: 16px;
 }
 
 .report-output {
     background: var(--control-bg);
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
     color: var(--text-main);
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 12px;
@@ -479,8 +592,8 @@ p {
 
 .shortcut-status {
     color: var(--accent-color);
-    font-size: 13px;
-    font-weight: 700;
+    font-size: 12.5px;
+    font-weight: 650;
     line-height: 1.4;
     text-align: right;
     word-break: break-word;
@@ -492,6 +605,8 @@ p {
     min-height: 18px;
     text-align: right;
 }
+
+/* ---- Switch ------------------------------------------------------------- */
 
 .switch {
     display: inline-flex;
@@ -505,33 +620,32 @@ p {
 
 .switch-compact {
     justify-content: flex-end;
-    min-width: 52px;
+    min-width: 44px;
 }
 
 .switch-track {
-    background: #5b6470;
-    border: 1px solid #7b8592;
+    background: color-mix(in srgb, var(--text-muted) 38%, transparent);
+    border: 1px solid transparent;
     border-radius: 999px;
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
     display: inline-flex;
     flex: 0 0 auto;
-    height: 28px;
+    height: 26px;
     position: relative;
-    transition: background-color 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
-    width: 48px;
+    transition: background-color 180ms var(--ease-out);
+    width: 44px;
 }
 
 .switch-track::after {
     background: #ffffff;
     border-radius: 50%;
-    box-shadow: 0 1px 3px rgba(15, 23, 42, 0.3);
+    box-shadow: 0 1px 3px rgba(15, 23, 42, 0.35);
     content: "";
-    height: 22px;
+    height: 20px;
     left: 2px;
     position: absolute;
     top: 2px;
-    transition: transform 140ms ease;
-    width: 22px;
+    transition: transform 180ms var(--ease-out);
+    width: 20px;
 }
 
 .switch-text {
@@ -562,22 +676,23 @@ p {
 }
 
 .switch input[type="checkbox"]:checked + .switch-track {
-    background: #34c759;
-    border-color: #34c759;
+    background: var(--accent-color);
 }
 
 .switch input[type="checkbox"]:checked + .switch-track::after {
-    transform: translateX(20px);
+    transform: translateX(18px);
 }
 
 .switch input[type="checkbox"]:focus-visible + .switch-track {
-    box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.28);
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
 }
 
 .switch input[type="checkbox"]:disabled + .switch-track {
-    opacity: 0.6;
-    box-shadow: none;
+    opacity: 0.55;
 }
+
+/* ---- Inputs ------------------------------------------------------------- */
 
 .select-control {
     display: flex;
@@ -613,9 +728,9 @@ p {
 }
 
 input[type="color"] {
-    width: 42px;
-    height: 34px;
-    border: 1px solid var(--border-color);
+    width: 44px;
+    height: 32px;
+    border: 1px solid var(--border-subtle);
     border-radius: 8px;
     background: var(--control-bg);
     cursor: pointer;
@@ -623,9 +738,9 @@ input[type="color"] {
 }
 
 select {
-    min-width: 150px;
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
+    min-width: 160px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-control);
     background: var(--control-bg);
     color: var(--text-main);
     font: inherit;
@@ -634,8 +749,8 @@ select {
 
 input[type="date"] {
     min-width: 150px;
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-control);
     background: var(--control-bg);
     color: var(--text-main);
     font: inherit;
@@ -656,8 +771,8 @@ input[type="password"],
 input[type="number"] {
     width: 100%;
     min-width: 150px;
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-control);
     background: var(--control-bg);
     color: var(--text-main);
     font: inherit;
@@ -668,8 +783,10 @@ input[type="text"]:focus-visible,
 input[type="password"]:focus-visible,
 input[type="number"]:focus-visible,
 input[type="date"]:focus-visible,
+textarea:focus-visible,
 select:focus-visible {
     border-color: var(--accent-color);
+    box-shadow: 0 0 0 3px var(--accent-faint);
     outline: none;
 }
 
@@ -692,26 +809,111 @@ input[type="checkbox"]:disabled {
     color: var(--danger-color);
 }
 
+/* ---- Buttons ------------------------------------------------------------ */
+
 .secondary-button {
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-control);
     background: var(--control-bg);
     color: var(--text-main);
     cursor: pointer;
     font: inherit;
-    font-weight: 700;
-    padding: 9px 12px;
+    font-size: 13px;
+    font-weight: 650;
+    padding: 8px 14px;
+    text-align: center;
+    text-decoration: none;
+    transition: border-color 130ms var(--ease-out), background-color 130ms var(--ease-out), color 130ms var(--ease-out), transform 100ms var(--ease-out);
 }
 
 .secondary-button:hover,
 .secondary-button:focus-visible {
+    background: var(--accent-faint);
     border-color: var(--accent-color);
     color: var(--accent-color);
     outline: none;
 }
 
+.secondary-button:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+}
+
+.secondary-button:active {
+    transform: translateY(1px);
+}
+
+.secondary-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+/* ---- Dialog ------------------------------------------------------------- */
+
+.confirm-dialog {
+    width: min(400px, calc(100vw - 32px));
+    border: 1px solid var(--border-subtle);
+    border-radius: 16px;
+    background: var(--surface-bg);
+    color: var(--text-main);
+    box-shadow:
+        0 4px 12px rgba(0, 0, 0, 0.18),
+        0 16px 40px rgba(0, 0, 0, 0.22);
+    padding: 22px;
+}
+
+.confirm-dialog[open] {
+    animation: confirmDialogIn 200ms var(--ease-out) both;
+}
+
+@keyframes confirmDialogIn {
+    from {
+        opacity: 0;
+        transform: scale(0.96);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+.confirm-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(3px);
+}
+
+.confirm-dialog h2 {
+    font-size: 16px;
+    margin-bottom: 8px;
+}
+
+.confirm-dialog p {
+    margin-top: 0;
+}
+
+.confirm-dialog-actions {
+    justify-content: flex-end;
+    margin-top: 18px;
+}
+
+.confirm-dialog-confirm {
+    background: var(--danger-soft);
+    border-color: color-mix(in srgb, var(--danger-color) 40%, transparent);
+    color: var(--danger-color);
+}
+
+.confirm-dialog-confirm:hover,
+.confirm-dialog-confirm:focus-visible {
+    background: var(--danger-color);
+    border-color: var(--danger-color);
+    color: var(--surface-bg);
+}
+
+/* ---- Footer ------------------------------------------------------------- */
+
 .made-by {
-    border-top: 1px solid var(--border-color);
+    border-top: 1px solid var(--border-subtle);
     color: var(--text-muted);
     font-size: 13px;
     margin-top: auto;
@@ -731,45 +933,109 @@ input[type="checkbox"]:disabled {
     outline: none;
 }
 
-@media (max-width: 720px) {
-    .settings-body {
-        flex-direction: column;
+.made-by a.made-by-contributors {
+    color: var(--text-muted);
+    font-weight: 600;
+}
+
+/* ---- Responsive --------------------------------------------------------- */
+
+@media (max-width: 900px) {
+    .settings {
+        padding: 20px 16px 20px;
     }
 
+    h1 {
+        font-size: 22px;
+    }
+
+    .page-header {
+        margin-bottom: 14px;
+    }
+
+    .page-header p {
+        font-size: 13px;
+        margin-top: 3px;
+    }
+
+    .settings-body {
+        flex-direction: column;
+        gap: 14px;
+    }
+
+    /* The section nav becomes a sticky, horizontally scrollable tab bar. */
     .settings-nav {
+        flex: none;
         flex-direction: row;
-        flex-wrap: wrap;
-        position: static;
-        width: 100%;
+        gap: 4px;
+        align-self: stretch;
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        margin: 0 -16px;
+        padding: 10px 16px;
+        overflow-x: auto;
+        background: color-mix(in srgb, var(--page-bg) 90%, transparent);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        scrollbar-width: none;
+    }
+
+    .settings-nav::-webkit-scrollbar {
+        display: none;
+    }
+
+    .settings-nav-item {
+        flex: 0 0 auto;
+        padding: 8px 12px;
+    }
+
+    .settings-nav-item[aria-selected="true"]::before {
+        top: auto;
+        left: 12px;
+        right: 12px;
+        bottom: 0;
+        width: auto;
+        height: 3px;
     }
 
     .settings-nav-item-experimental {
-        margin-top: 0;
-        margin-left: auto;
-        border-top: none;
-        padding-top: 10px;
+        margin: 0 0 0 10px;
+    }
+
+    .settings-nav-item-experimental::after {
+        top: 7px;
+        bottom: 7px;
+        left: -7px;
+        right: auto;
+        width: 1px;
+        height: auto;
     }
 }
 
-@media (max-width: 560px) {
-    .page-header,
-    .setting-row {
+@media (max-width: 620px) {
+    .page-header {
         align-items: flex-start;
         flex-direction: column;
     }
 
-    .custom-theme-controls,
-    .custom-theme-grid {
-        width: 100%;
+    .setting-row {
+        gap: 14px;
+        padding: 14px;
     }
 
-    .custom-theme-grid {
-        grid-template-columns: 1fr;
+    .setting-card > .setting-note {
+        padding: 13px 14px;
     }
 
-    .date-setting-controls {
-        justify-content: space-between;
-        width: 100%;
+    /* Only rows whose controls are genuinely wide stack vertically; simple
+       toggle rows keep the label-left / switch-right layout. */
+    .setting-row:has(.shortcut-controls),
+    .setting-row:has(.date-setting-controls),
+    .setting-row:has(.custom-theme-controls),
+    .setting-row:has(.custom-theme-grid) {
+        align-items: stretch;
+        flex-direction: column;
     }
 
     .shortcut-controls {
@@ -781,14 +1047,38 @@ input[type="checkbox"]:disabled {
         text-align: left;
     }
 
+    .custom-theme-controls,
+    .custom-theme-grid {
+        justify-items: stretch;
+        max-width: none;
+        width: 100%;
+    }
+
+    .custom-theme-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .save-status {
+        text-align: left;
+    }
+
+    .date-setting-controls {
+        align-items: stretch;
+        width: 100%;
+    }
+
+    .date-control-row {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+    }
+
     .date-control {
         justify-content: space-between;
         width: 100%;
     }
 
-    .option-grid .switch {
-        justify-content: space-between;
-        width: 100%;
+    .actions-row .secondary-button {
+        flex: 1 1 auto;
     }
 }
 

--- a/menu/settings.html
+++ b/menu/settings.html
@@ -17,13 +17,34 @@
 
       <div class="settings-body">
         <nav class="settings-nav" role="tablist" aria-orientation="vertical" aria-label="Settings categories">
-          <button class="settings-nav-item" type="button" role="tab" id="nav-appearance" aria-controls="panel-appearance" aria-selected="true" data-target="appearance" data-i18n="groupAppearance">Appearance</button>
-          <button class="settings-nav-item" type="button" role="tab" id="nav-cleanup" aria-controls="panel-cleanup" aria-selected="false" tabindex="-1" data-target="cleanup" data-i18n="groupCleanup">Cleanup</button>
-          <button class="settings-nav-item" type="button" role="tab" id="nav-features" aria-controls="panel-features" aria-selected="false" tabindex="-1" data-target="features" data-i18n="groupFeatures">Features</button>
-          <button class="settings-nav-item" type="button" role="tab" id="nav-timetable" aria-controls="panel-timetable" aria-selected="false" tabindex="-1" data-target="timetable" data-i18n="groupTimetable">Timetable</button>
-          <button class="settings-nav-item" type="button" role="tab" id="nav-updates" aria-controls="panel-updates" aria-selected="false" tabindex="-1" data-target="updates" data-i18n="groupUpdates">Updates</button>
-          <button class="settings-nav-item" type="button" role="tab" id="nav-debug" aria-controls="panel-debug" aria-selected="false" tabindex="-1" data-target="debug" data-i18n="groupDebug">Debug</button>
-          <button class="settings-nav-item settings-nav-item-experimental" type="button" role="tab" id="ExperimentalSettingsButton" aria-controls="panel-experimental" aria-selected="false" tabindex="-1" data-target="experimental" data-i18n="experimentalButton">Experimental</button>
+          <button class="settings-nav-item" type="button" role="tab" id="nav-appearance" aria-controls="panel-appearance" aria-selected="true" data-target="appearance">
+            <svg class="nav-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 3a9 9 0 0 1 0 18z" fill="currentColor" stroke="none"/></svg>
+            <span data-i18n="groupAppearance">Appearance</span>
+          </button>
+          <button class="settings-nav-item" type="button" role="tab" id="nav-cleanup" aria-controls="panel-cleanup" aria-selected="false" tabindex="-1" data-target="cleanup">
+            <svg class="nav-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/><path d="m5 11 9 9"/></svg>
+            <span data-i18n="groupCleanup">Cleanup</span>
+          </button>
+          <button class="settings-nav-item" type="button" role="tab" id="nav-features" aria-controls="panel-features" aria-selected="false" tabindex="-1" data-target="features">
+            <svg class="nav-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.9 5.7a2 2 0 0 0 1.4 1.4L21 12l-5.7 1.9a2 2 0 0 0-1.4 1.4L12 21l-1.9-5.7a2 2 0 0 0-1.4-1.4L3 12l5.7-1.9a2 2 0 0 0 1.4-1.4L12 3z"/></svg>
+            <span data-i18n="groupFeatures">Features</span>
+          </button>
+          <button class="settings-nav-item" type="button" role="tab" id="nav-timetable" aria-controls="panel-timetable" aria-selected="false" tabindex="-1" data-target="timetable">
+            <svg class="nav-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="17" rx="2"/><path d="M16 2v4M8 2v4M3 9h18"/></svg>
+            <span data-i18n="groupTimetable">Timetable</span>
+          </button>
+          <button class="settings-nav-item" type="button" role="tab" id="nav-updates" aria-controls="panel-updates" aria-selected="false" tabindex="-1" data-target="updates">
+            <svg class="nav-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="m7 11 5 5 5-5"/><path d="M5 21h14"/></svg>
+            <span data-i18n="groupUpdates">Updates</span>
+          </button>
+          <button class="settings-nav-item" type="button" role="tab" id="nav-debug" aria-controls="panel-debug" aria-selected="false" tabindex="-1" data-target="debug">
+            <svg class="nav-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m4 17 6-6-6-6"/><path d="M12 19h8"/></svg>
+            <span data-i18n="groupDebug">Debug</span>
+          </button>
+          <button class="settings-nav-item settings-nav-item-experimental" type="button" role="tab" id="ExperimentalSettingsButton" aria-controls="panel-experimental" aria-selected="false" tabindex="-1" data-target="experimental">
+            <svg class="nav-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2h6"/><path d="M10 2v7.5L4.7 19a1.8 1.8 0 0 0 1.6 2.7h11.4a1.8 1.8 0 0 0 1.6-2.7L14 9.5V2"/><path d="M7 15h10"/></svg>
+            <span data-i18n="experimentalButton">Experimental</span>
+          </button>
         </nav>
 
         <div class="settings-content">
@@ -31,127 +52,129 @@
       <section class="setting-group" id="panel-appearance" role="tabpanel" aria-labelledby="appearance-heading nav-appearance" tabindex="0">
         <h2 id="appearance-heading" data-i18n="groupAppearance">Appearance</h2>
 
-        <div class="setting-row">
-          <div>
-            <h3>
-              <span data-i18n="themesLabel">Themes</span>
-              <span class="setting-tag setting-tag-wip" data-i18n="wipBadge">WIP</span>
-            </h3>
-            <p data-i18n="themesDesc">Apply Edupage Extras colors across Edupage and the extension menus.</p>
-          </div>
-          <label class="switch switch-compact" for="DarkModeCheckbox">
-            <input type="checkbox" id="DarkModeCheckbox">
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleThemes">Toggle themes</span>
-          </label>
-        </div>
-
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="themeHotkey">Theme Hotkey</h3>
-            <p data-i18n="themeHotkeyDesc">Optional. Add a Chrome extension shortcut for toggling themes on or off.</p>
-          </div>
-          <div class="shortcut-controls">
-            <button class="secondary-button" id="OpenShortcutSettingsButton" type="button" data-i18n="openShortcutSettings">Open Shortcut Settings</button>
-            <span class="shortcut-status" id="ThemeShortcutStatus" data-i18n="noHotkey">No hotkey assigned.</span>
-          </div>
-        </div>
-
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="themeLabel">Theme</h3>
-            <p data-i18n="themeDesc">Choose the colors Edupage Extras applies to Edupage.</p>
-          </div>
-          <label class="select-control" for="ThemeSelect">
-            <span data-i18n="themeLabel">Theme</span>
-            <select id="ThemeSelect">
-              <option value="dark" data-i18n="themeOptionDark">Midnight Blue</option>
-              <option value="ocean" data-i18n="themeOptionOcean">Ocean Cyan</option>
-              <option value="forest" data-i18n="themeOptionForest">Forest Green</option>
-              <option value="emerald" data-i18n="themeOptionEmerald">Emerald Green</option>
-              <option value="pink" data-i18n="themeOptionPink">Rose Pink</option>
-              <option value="purple" data-i18n="themeOptionPurple">Royal Purple</option>
-              <option value="custom" data-i18n="themeOptionCustom">Custom</option>
-              <option value="light" data-i18n="themeOptionLight">Light</option>
-            </select>
-          </label>
-        </div>
-
-        <div class="setting-note setting-note-warning" role="note" aria-label="Theme disclaimer">
-          <strong data-i18n="themeDisclaimerTitle">Theme Disclaimer</strong>
-          <p data-i18n="themeDisclaimerText">During an online test or exam, a recolored EduPage looks different from the standard page — which can draw a teacher's attention or be mistaken for tampering. Switch to the default theme (or turn themes off) while you take the test.</p>
-        </div>
-
-        <div class="setting-row custom-theme-row" id="CustomThemePanel" hidden>
-          <div>
-            <h3 data-i18n="customThemeLabel">Custom Theme</h3>
-            <p data-i18n="customThemeDesc">Build your own Edupage Extras colors.</p>
-          </div>
-          <div class="custom-theme-controls">
-            <div class="custom-theme-grid">
-              <label>
-                <span data-i18n="customColorBg">Background</span>
-                <input type="color" id="CustomBgBase">
-              </label>
-              <label>
-                <span data-i18n="customColorSurface">Surface</span>
-                <input type="color" id="CustomBgRaised">
-              </label>
-              <label>
-                <span data-i18n="customColorControls">Controls</span>
-                <input type="color" id="CustomBgElevated">
-              </label>
-              <label>
-                <span data-i18n="customColorMuted">Muted Surface</span>
-                <input type="color" id="CustomBgMuted">
-              </label>
-              <label>
-                <span data-i18n="customColorBorder">Border</span>
-                <input type="color" id="CustomBorder">
-              </label>
-              <label>
-                <span data-i18n="customColorTextMain">Main Text</span>
-                <input type="color" id="CustomTextMain">
-              </label>
-              <label>
-                <span data-i18n="customColorTextMuted">Muted Text</span>
-                <input type="color" id="CustomTextMuted">
-              </label>
-              <label>
-                <span data-i18n="customColorAccent">Accent</span>
-                <input type="color" id="CustomAccent">
-              </label>
-              <label>
-                <span data-i18n="customColorWarning">Warning</span>
-                <input type="color" id="CustomWarning">
-              </label>
-              <label>
-                <span data-i18n="customColorDanger">Danger</span>
-                <input type="color" id="CustomDanger">
-              </label>
-              <label>
-                <span data-i18n="customColorTableHeader">Table Header</span>
-                <input type="color" id="CustomTableHeaderBg">
-              </label>
-              <label>
-                <span data-i18n="timetableHighlightColorRoomChange">Room Change Color</span>
-                <input type="color" id="CustomRozvrhRoomChange">
-              </label>
-              <label>
-                <span data-i18n="timetableHighlightColorSubstitution">Substitution Color</span>
-                <input type="color" id="CustomRozvrhSubstitution">
-              </label>
+        <div class="setting-card">
+          <div class="setting-row">
+            <div>
+              <h3>
+                <span data-i18n="themesLabel">Themes</span>
+                <span class="setting-tag setting-tag-wip" data-i18n="wipBadge">WIP</span>
+              </h3>
+              <p data-i18n="themesDesc">Apply Edupage Extras colors across Edupage and the extension menus.</p>
             </div>
-            <label class="custom-theme-import" for="CustomThemeImport">
-              <span data-i18n="importExport">Import / Export</span>
-              <textarea id="CustomThemeImport" rows="5" placeholder="Paste a shared Edupage Extras custom theme here." data-i18n-attr="placeholder:customThemePlaceholder"></textarea>
+            <label class="switch switch-compact" for="DarkModeCheckbox">
+              <input type="checkbox" id="DarkModeCheckbox">
+              <span class="switch-track" aria-hidden="true"></span>
+              <span class="sr-only" data-i18n="toggleThemes">Toggle themes</span>
             </label>
-            <div class="actions-row">
-              <button class="secondary-button" id="ExportCustomThemeButton" type="button" data-i18n="exportTheme">Export Theme</button>
-              <button class="secondary-button" id="ImportCustomThemeButton" type="button" data-i18n="importTheme">Import Theme</button>
-              <button class="secondary-button" id="ResetCustomThemeButton" type="button" data-i18n="resetCustomTheme">Reset Custom Theme</button>
+          </div>
+
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="themeHotkey">Theme Hotkey</h3>
+              <p data-i18n="themeHotkeyDesc">Optional. Add a Chrome extension shortcut for toggling themes on or off.</p>
             </div>
-            <span class="save-status" id="CustomThemeStatus" role="status"></span>
+            <div class="shortcut-controls">
+              <button class="secondary-button" id="OpenShortcutSettingsButton" type="button" data-i18n="openShortcutSettings">Open Shortcut Settings</button>
+              <span class="shortcut-status" id="ThemeShortcutStatus" data-i18n="noHotkey">No hotkey assigned.</span>
+            </div>
+          </div>
+
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="themeLabel">Theme</h3>
+              <p data-i18n="themeDesc">Choose the colors Edupage Extras applies to Edupage.</p>
+            </div>
+            <label class="select-control" for="ThemeSelect">
+              <span class="sr-only" data-i18n="themeLabel">Theme</span>
+              <select id="ThemeSelect">
+                <option value="dark" data-i18n="themeOptionDark">Midnight Blue</option>
+                <option value="ocean" data-i18n="themeOptionOcean">Ocean Cyan</option>
+                <option value="forest" data-i18n="themeOptionForest">Forest Green</option>
+                <option value="emerald" data-i18n="themeOptionEmerald">Emerald Green</option>
+                <option value="pink" data-i18n="themeOptionPink">Rose Pink</option>
+                <option value="purple" data-i18n="themeOptionPurple">Royal Purple</option>
+                <option value="custom" data-i18n="themeOptionCustom">Custom</option>
+                <option value="light" data-i18n="themeOptionLight">Light</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="setting-note setting-note-warning" role="note" aria-label="Theme disclaimer">
+            <strong data-i18n="themeDisclaimerTitle">Theme Disclaimer</strong>
+            <p data-i18n="themeDisclaimerText">During an online test or exam, a recolored EduPage looks different from the standard page — which can draw a teacher's attention or be mistaken for tampering. Switch to the default theme (or turn themes off) while you take the test.</p>
+          </div>
+
+          <div class="setting-row custom-theme-row" id="CustomThemePanel" hidden>
+            <div>
+              <h3 data-i18n="customThemeLabel">Custom Theme</h3>
+              <p data-i18n="customThemeDesc">Build your own Edupage Extras colors.</p>
+            </div>
+            <div class="custom-theme-controls">
+              <div class="custom-theme-grid">
+                <label>
+                  <span data-i18n="customColorBg">Background</span>
+                  <input type="color" id="CustomBgBase">
+                </label>
+                <label>
+                  <span data-i18n="customColorSurface">Surface</span>
+                  <input type="color" id="CustomBgRaised">
+                </label>
+                <label>
+                  <span data-i18n="customColorControls">Controls</span>
+                  <input type="color" id="CustomBgElevated">
+                </label>
+                <label>
+                  <span data-i18n="customColorMuted">Muted Surface</span>
+                  <input type="color" id="CustomBgMuted">
+                </label>
+                <label>
+                  <span data-i18n="customColorBorder">Border</span>
+                  <input type="color" id="CustomBorder">
+                </label>
+                <label>
+                  <span data-i18n="customColorTextMain">Main Text</span>
+                  <input type="color" id="CustomTextMain">
+                </label>
+                <label>
+                  <span data-i18n="customColorTextMuted">Muted Text</span>
+                  <input type="color" id="CustomTextMuted">
+                </label>
+                <label>
+                  <span data-i18n="customColorAccent">Accent</span>
+                  <input type="color" id="CustomAccent">
+                </label>
+                <label>
+                  <span data-i18n="customColorWarning">Warning</span>
+                  <input type="color" id="CustomWarning">
+                </label>
+                <label>
+                  <span data-i18n="customColorDanger">Danger</span>
+                  <input type="color" id="CustomDanger">
+                </label>
+                <label>
+                  <span data-i18n="customColorTableHeader">Table Header</span>
+                  <input type="color" id="CustomTableHeaderBg">
+                </label>
+                <label>
+                  <span data-i18n="timetableHighlightColorRoomChange">Room Change Color</span>
+                  <input type="color" id="CustomRozvrhRoomChange">
+                </label>
+                <label>
+                  <span data-i18n="timetableHighlightColorSubstitution">Substitution Color</span>
+                  <input type="color" id="CustomRozvrhSubstitution">
+                </label>
+              </div>
+              <label class="custom-theme-import" for="CustomThemeImport">
+                <span data-i18n="importExport">Import / Export</span>
+                <textarea id="CustomThemeImport" rows="5" placeholder="Paste a shared Edupage Extras custom theme here." data-i18n-attr="placeholder:customThemePlaceholder"></textarea>
+              </label>
+              <div class="actions-row">
+                <button class="secondary-button" id="ExportCustomThemeButton" type="button" data-i18n="exportTheme">Export Theme</button>
+                <button class="secondary-button" id="ImportCustomThemeButton" type="button" data-i18n="importTheme">Import Theme</button>
+                <button class="secondary-button" id="ResetCustomThemeButton" type="button" data-i18n="resetCustomTheme">Reset Custom Theme</button>
+              </div>
+              <span class="save-status" id="CustomThemeStatus" role="status"></span>
+            </div>
           </div>
         </div>
       </section>
@@ -159,200 +182,204 @@
       <section class="setting-group" id="panel-cleanup" role="tabpanel" aria-labelledby="cleanup-heading nav-cleanup" tabindex="0" hidden>
         <h2 id="cleanup-heading" data-i18n="groupCleanup">Cleanup</h2>
 
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="centeredLayout">Centered Layout</h3>
-            <p data-i18n="centeredLayoutDesc">Keep the top schedule and main content aligned in the middle.</p>
+        <div class="setting-card">
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="centeredLayout">Centered Layout</h3>
+              <p data-i18n="centeredLayoutDesc">Keep the top schedule and main content aligned in the middle.</p>
+            </div>
+            <label class="switch switch-compact" for="CleanUiCheckbox">
+              <input type="checkbox" id="CleanUiCheckbox">
+              <span class="switch-track" aria-hidden="true"></span>
+              <span class="sr-only" data-i18n="toggleCenteredLayout">Toggle centered layout</span>
+            </label>
           </div>
-          <label class="switch switch-compact" for="CleanUiCheckbox">
-            <input type="checkbox" id="CleanUiCheckbox">
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleCenteredLayout">Toggle centered layout</span>
-          </label>
-        </div>
 
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="hideHelpText">Hide Help Text</h3>
-            <p data-i18n="hideHelpTextDesc">Hide the top-right Edupage help greeting.</p>
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="hideHelpText">Hide Help Text</h3>
+              <p data-i18n="hideHelpTextDesc">Hide the top-right Edupage help greeting.</p>
+            </div>
+            <label class="switch switch-compact" for="HideHelpTextCheckbox">
+              <input type="checkbox" id="HideHelpTextCheckbox">
+              <span class="switch-track" aria-hidden="true"></span>
+              <span class="sr-only" data-i18n="toggleHelpText">Toggle help text</span>
+            </label>
           </div>
-          <label class="switch switch-compact" for="HideHelpTextCheckbox">
-            <input type="checkbox" id="HideHelpTextCheckbox">
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleHelpText">Toggle help text</span>
-          </label>
-        </div>
 
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="mobileResponsive">Mobile-Responsive Layout</h3>
-            <p data-i18n="mobileResponsiveDesc">Inject structural CSS (flex-wrap, scrollable tables, scaled sidebar/fonts) to make Edupage usable on small screens. Off by default — not fully verified on every page yet.</p>
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="mobileResponsive">Mobile-Responsive Layout</h3>
+              <p data-i18n="mobileResponsiveDesc">Inject structural CSS (flex-wrap, scrollable tables, scaled sidebar/fonts) to make Edupage usable on small screens. Off by default — not fully verified on every page yet.</p>
+            </div>
+            <label class="switch switch-compact" for="MobileResponsiveCheckbox">
+              <input type="checkbox" id="MobileResponsiveCheckbox">
+              <span class="switch-track" aria-hidden="true"></span>
+              <span class="sr-only" data-i18n="toggleMobileResponsive">Toggle mobile-responsive layout</span>
+            </label>
           </div>
-          <label class="switch switch-compact" for="MobileResponsiveCheckbox">
-            <input type="checkbox" id="MobileResponsiveCheckbox">
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleMobileResponsive">Toggle mobile-responsive layout</span>
-          </label>
         </div>
-
       </section>
 
       <section class="setting-group" id="panel-features" role="tabpanel" aria-labelledby="features-heading nav-features" tabindex="0" hidden>
         <h2 id="features-heading" data-i18n="groupFeatures">Features</h2>
 
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="timetableHighlights">Timetable Change Highlights</h3>
-            <p data-i18n="timetableHighlightsDesc">Color-code substitutions (orange) and classroom changes (blue) on the main page schedule widget.</p>
-          </div>
-          <label class="switch switch-compact" for="TimetableHighlightsCheckbox">
-            <input type="checkbox" id="TimetableHighlightsCheckbox">
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleTimetableHighlights">Toggle timetable change highlights</span>
-          </label>
-        </div>
-
-        <div class="setting-row" id="TimetableHighlightColorsRow">
-          <div>
-            <h3 data-i18n="timetableHighlightColorsLabel">Highlight Colors</h3>
-          </div>
-          <div class="custom-theme-grid timetable-highlight-colors">
-            <label>
-              <span data-i18n="timetableHighlightColorRoomChange">Room Change Color</span>
-              <input type="color" id="RozvrhRoomChangeColor">
-            </label>
-            <label>
-              <span data-i18n="timetableHighlightColorSubstitution">Substitution Color</span>
-              <input type="color" id="RozvrhSubstitutionColor">
+        <div class="setting-card">
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="timetableHighlights">Timetable Change Highlights</h3>
+              <p data-i18n="timetableHighlightsDesc">Color-code substitutions (orange) and classroom changes (blue) on the main page schedule widget.</p>
+            </div>
+            <label class="switch switch-compact" for="TimetableHighlightsCheckbox">
+              <input type="checkbox" id="TimetableHighlightsCheckbox">
+              <span class="switch-track" aria-hidden="true"></span>
+              <span class="sr-only" data-i18n="toggleTimetableHighlights">Toggle timetable change highlights</span>
             </label>
           </div>
-        </div>
 
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="gradeBadges">Grade Badges</h3>
-            <p data-i18n="gradeBadgesDesc">Show average badges, bars, and the overall average row on the grades page.</p>
-          </div>
-          <label class="switch switch-compact" for="GradeBadgesCheckbox">
-            <input type="checkbox" id="GradeBadgesCheckbox">
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleGradeBadges">Toggle grade badges</span>
-          </label>
-        </div>
-
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="subjectAttendance">Grades Page Subject Attendance</h3>
-            <p data-i18n-html="subjectAttendanceDesc">Inject per-subject absence percentage and total lesson hours into each row on the <strong>Grades</strong> page, using official EduPage data.</p>
-          </div>
-          <label class="switch switch-compact" for="GradesAttendanceCheckbox">
-            <input type="checkbox" id="GradesAttendanceCheckbox">
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleSubjectAttendance">Toggle subject attendance</span>
-          </label>
-        </div>
-
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="attendancePercentages">Attendance Summary Percentages</h3>
-            <p data-i18n-html="attendancePercentagesDesc">Add the current-halfyear absence percentage into EduPage's own <strong>Attendance</strong> summary table (the standalone attendance page, not the Grades page).</p>
-          </div>
-          <label class="switch switch-compact" for="AttendancePercentagesCheckbox">
-            <input type="checkbox" id="AttendancePercentagesCheckbox">
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleAttendancePercentages">Toggle attendance percentages</span>
-          </label>
-        </div>
-
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="secondHalfStart">Second Halfyear Start Date</h3>
-            <p data-i18n="secondHalfStartDesc">Override when the second halfyear begins for attendance calculations. Leave this empty to use EduPage's default date for the current school year.</p>
-          </div>
-          <div class="date-setting-controls">
-            <div class="date-control-row">
-              <label class="date-control" for="HalfyearStartDateInput">
-                <span data-i18n="dateLabel">Date</span>
-                <input type="date" id="HalfyearStartDateInput">
-              </label>
-              <button class="secondary-button" id="ResetHalfyearStartDateButton" type="button" data-i18n="useEdupageDefault">Use EduPage Default</button>
+          <div class="setting-row" id="TimetableHighlightColorsRow">
+            <div>
+              <h3 data-i18n="timetableHighlightColorsLabel">Highlight Colors</h3>
             </div>
-            <small class="date-default-hint" id="HalfyearStartDefaultHint"></small>
-          </div>
-        </div>
-
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="secondHalfEnd">Second Halfyear End Date</h3>
-            <p data-i18n="secondHalfEndDesc">Override when the second halfyear ends for predicted attendance in grades. Leave this empty to use EduPage's default end date for the current school year.</p>
-          </div>
-          <div class="date-setting-controls">
-            <div class="date-control-row">
-              <label class="date-control" for="HalfyearEndDateInput">
-                <span data-i18n="dateLabel">Date</span>
-                <input type="date" id="HalfyearEndDateInput">
+            <div class="custom-theme-grid timetable-highlight-colors">
+              <label>
+                <span data-i18n="timetableHighlightColorRoomChange">Room Change Color</span>
+                <input type="color" id="RozvrhRoomChangeColor">
               </label>
-              <button class="secondary-button" id="ResetHalfyearEndDateButton" type="button" data-i18n="useEdupageDefault">Use EduPage Default</button>
+              <label>
+                <span data-i18n="timetableHighlightColorSubstitution">Substitution Color</span>
+                <input type="color" id="RozvrhSubstitutionColor">
+              </label>
             </div>
-            <small class="date-default-hint" id="HalfyearEndDefaultHint"></small>
+          </div>
+
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="gradeBadges">Grade Badges</h3>
+              <p data-i18n="gradeBadgesDesc">Show average badges, bars, and the overall average row on the grades page.</p>
+            </div>
+            <label class="switch switch-compact" for="GradeBadgesCheckbox">
+              <input type="checkbox" id="GradeBadgesCheckbox">
+              <span class="switch-track" aria-hidden="true"></span>
+              <span class="sr-only" data-i18n="toggleGradeBadges">Toggle grade badges</span>
+            </label>
+          </div>
+
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="subjectAttendance">Grades Page Subject Attendance</h3>
+              <p data-i18n-html="subjectAttendanceDesc">Inject per-subject absence percentage and total lesson hours into each row on the <strong>Grades</strong> page, using official EduPage data.</p>
+            </div>
+            <label class="switch switch-compact" for="GradesAttendanceCheckbox">
+              <input type="checkbox" id="GradesAttendanceCheckbox">
+              <span class="switch-track" aria-hidden="true"></span>
+              <span class="sr-only" data-i18n="toggleSubjectAttendance">Toggle subject attendance</span>
+            </label>
+          </div>
+
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="attendancePercentages">Attendance Summary Percentages</h3>
+              <p data-i18n-html="attendancePercentagesDesc">Add the current-halfyear absence percentage into EduPage's own <strong>Attendance</strong> summary table (the standalone attendance page, not the Grades page).</p>
+            </div>
+            <label class="switch switch-compact" for="AttendancePercentagesCheckbox">
+              <input type="checkbox" id="AttendancePercentagesCheckbox">
+              <span class="switch-track" aria-hidden="true"></span>
+              <span class="sr-only" data-i18n="toggleAttendancePercentages">Toggle attendance percentages</span>
+            </label>
+          </div>
+
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="secondHalfStart">Second Halfyear Start Date</h3>
+              <p data-i18n="secondHalfStartDesc">Override when the second halfyear begins for attendance calculations. Leave this empty to use EduPage's default date for the current school year.</p>
+            </div>
+            <div class="date-setting-controls">
+              <div class="date-control-row">
+                <label class="date-control" for="HalfyearStartDateInput">
+                  <span data-i18n="dateLabel">Date</span>
+                  <input type="date" id="HalfyearStartDateInput">
+                </label>
+                <button class="secondary-button" id="ResetHalfyearStartDateButton" type="button" data-i18n="useEdupageDefault">Use EduPage Default</button>
+              </div>
+              <small class="date-default-hint" id="HalfyearStartDefaultHint"></small>
+            </div>
+          </div>
+
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="secondHalfEnd">Second Halfyear End Date</h3>
+              <p data-i18n="secondHalfEndDesc">Override when the second halfyear ends for predicted attendance in grades. Leave this empty to use EduPage's default end date for the current school year.</p>
+            </div>
+            <div class="date-setting-controls">
+              <div class="date-control-row">
+                <label class="date-control" for="HalfyearEndDateInput">
+                  <span data-i18n="dateLabel">Date</span>
+                  <input type="date" id="HalfyearEndDateInput">
+                </label>
+                <button class="secondary-button" id="ResetHalfyearEndDateButton" type="button" data-i18n="useEdupageDefault">Use EduPage Default</button>
+              </div>
+              <small class="date-default-hint" id="HalfyearEndDefaultHint"></small>
+            </div>
+          </div>
+
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="autoLogin">Auto-Login</h3>
+              <p data-i18n="autoLoginDesc">Automatically clicks through the EduPage login (account picker included) and submits once your browser autofills the saved password. Stops the moment you type anything yourself.</p>
+            </div>
+            <label class="switch switch-compact" for="AutoLoginCheckbox">
+              <input type="checkbox" id="AutoLoginCheckbox">
+              <span class="switch-track" aria-hidden="true"></span>
+              <span class="sr-only" data-i18n="toggleAutoLogin">Toggle auto-login</span>
+            </label>
+          </div>
+
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="ucivoExport">Curriculum Export</h3>
+              <p data-i18n="ucivoExportDesc">Add export buttons to a subject's Učivo page to download the topic plan (with taught dates) as .txt or .csv.</p>
+            </div>
+            <label class="switch switch-compact" for="UcivoExportCheckbox">
+              <input type="checkbox" id="UcivoExportCheckbox">
+              <span class="switch-track" aria-hidden="true"></span>
+              <span class="sr-only" data-i18n="toggleUcivoExport">Toggle curriculum export</span>
+            </label>
           </div>
         </div>
-
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="autoLogin">Auto-Login</h3>
-            <p data-i18n="autoLoginDesc">Automatically clicks through the EduPage login (account picker included) and submits once your browser autofills the saved password. Stops the moment you type anything yourself.</p>
-          </div>
-          <label class="switch switch-compact" for="AutoLoginCheckbox">
-            <input type="checkbox" id="AutoLoginCheckbox">
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleAutoLogin">Toggle auto-login</span>
-          </label>
-        </div>
-
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="ucivoExport">Curriculum Export</h3>
-            <p data-i18n="ucivoExportDesc">Add export buttons to a subject's Učivo page to download the topic plan (with taught dates) as .txt or .csv.</p>
-          </div>
-          <label class="switch switch-compact" for="UcivoExportCheckbox">
-            <input type="checkbox" id="UcivoExportCheckbox">
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleUcivoExport">Toggle curriculum export</span>
-          </label>
-        </div>
-
       </section>
 
       <section class="setting-group" id="panel-timetable" role="tabpanel" aria-labelledby="timetable-heading nav-timetable" tabindex="0" hidden>
         <h2 id="timetable-heading" data-i18n="groupTimetable">Timetable</h2>
 
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="exportTimetable">Export Timetable (.ics)</h3>
-            <p data-i18n="exportTimetableDesc">Download your timetable as an .ics file for Google Calendar, Apple Calendar, Outlook, etc. Briefly opens a hidden EduPage tab to read the timetable.</p>
-          </div>
-        </div>
-
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="exportTimetableIncludeChanges">Include this week's changes</h3>
-            <p data-i18n="exportTimetableIncludeChangesDesc">Keep this week's substitutions and room changes in the export.</p>
-          </div>
-          <label class="switch switch-compact" for="ExportTimetableIncludeChangesCheckbox">
-            <input type="checkbox" id="ExportTimetableIncludeChangesCheckbox" checked>
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleExportIncludeChanges">Toggle including this week's changes</span>
-          </label>
-        </div>
-
-        <div class="setting-row setting-row-stack">
-          <div class="setting-stack-controls">
-            <div class="actions-row">
-              <button class="secondary-button" id="ExportTimetableWeekButton" type="button" data-i18n="exportTimetableWeek">Export Current Week</button>
-              <button class="secondary-button" id="ExportTimetableHalfyearButton" type="button" data-i18n="exportTimetableHalfyear">Export Half-Year</button>
+        <div class="setting-card">
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="exportTimetable">Export Timetable (.ics)</h3>
+              <p data-i18n="exportTimetableDesc">Download your timetable as an .ics file for Google Calendar, Apple Calendar, Outlook, etc. Briefly opens a hidden EduPage tab to read the timetable.</p>
             </div>
-            <p id="ExportTimetableStatus" class="setting-note" role="status" aria-live="polite"></p>
+          </div>
+
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="exportTimetableIncludeChanges">Include this week's changes</h3>
+              <p data-i18n="exportTimetableIncludeChangesDesc">Keep this week's substitutions and room changes in the export.</p>
+            </div>
+            <label class="switch switch-compact" for="ExportTimetableIncludeChangesCheckbox">
+              <input type="checkbox" id="ExportTimetableIncludeChangesCheckbox" checked>
+              <span class="switch-track" aria-hidden="true"></span>
+              <span class="sr-only" data-i18n="toggleExportIncludeChanges">Toggle including this week's changes</span>
+            </label>
+          </div>
+
+          <div class="setting-row setting-row-stack">
+            <div class="setting-stack-controls">
+              <div class="actions-row">
+                <button class="secondary-button" id="ExportTimetableWeekButton" type="button" data-i18n="exportTimetableWeek">Export Current Week</button>
+                <button class="secondary-button" id="ExportTimetableHalfyearButton" type="button" data-i18n="exportTimetableHalfyear">Export Half-Year</button>
+              </div>
+              <p id="ExportTimetableStatus" class="setting-note" role="status" aria-live="polite"></p>
+            </div>
           </div>
         </div>
 
@@ -362,26 +389,28 @@
       <section class="setting-group" id="panel-updates" role="tabpanel" aria-labelledby="updates-heading nav-updates" tabindex="0" hidden>
         <h2 id="updates-heading" data-i18n="groupUpdates">Updates</h2>
 
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="updateReminders">Update Reminders</h3>
-            <p data-i18n="updateRemindersDesc">Check the public GitHub project for a newer unpacked version.</p>
+        <div class="setting-card">
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="updateReminders">Update Reminders</h3>
+              <p data-i18n="updateRemindersDesc">Check the public GitHub project for a newer unpacked version.</p>
+            </div>
+            <label class="switch switch-compact" for="UpdateReminderCheckbox">
+              <input type="checkbox" id="UpdateReminderCheckbox">
+              <span class="switch-track" aria-hidden="true"></span>
+              <span class="sr-only" data-i18n="toggleUpdateReminders">Toggle update reminders</span>
+            </label>
           </div>
-          <label class="switch switch-compact" for="UpdateReminderCheckbox">
-            <input type="checkbox" id="UpdateReminderCheckbox">
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleUpdateReminders">Toggle update reminders</span>
-          </label>
-        </div>
 
-        <div class="setting-row setting-row-stack">
-          <div>
-            <h3 data-i18n="versionCheck">Version Check</h3>
-            <p id="UpdateStatusText" data-i18n="noUpdateCheck">No update check has run yet.</p>
-          </div>
-          <div class="actions-row">
-            <button class="secondary-button" id="CheckUpdatesButton" type="button" data-i18n="checkForUpdates">Check For Updates</button>
-            <button class="secondary-button" id="OpenRepositoryButton" type="button" data-i18n="openGithub">Open GitHub</button>
+          <div class="setting-row setting-row-stack">
+            <div>
+              <h3 data-i18n="versionCheck">Version Check</h3>
+              <p id="UpdateStatusText" data-i18n="noUpdateCheck">No update check has run yet.</p>
+            </div>
+            <div class="actions-row">
+              <button class="secondary-button" id="CheckUpdatesButton" type="button" data-i18n="checkForUpdates">Check For Updates</button>
+              <button class="secondary-button" id="OpenRepositoryButton" type="button" data-i18n="openGithub">Open GitHub</button>
+            </div>
           </div>
         </div>
       </section>
@@ -389,46 +418,48 @@
       <section class="setting-group" id="panel-debug" role="tabpanel" aria-labelledby="debug-heading nav-debug" tabindex="0" hidden>
         <h2 id="debug-heading" data-i18n="groupDebug">Debug</h2>
 
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="previewUpdateToast">Preview Update Toast</h3>
-            <p data-i18n="previewUpdateToastDesc">Show the "what's new" toast on an open Edupage tab right now, without waiting for an actual version change.</p>
-          </div>
-          <button class="secondary-button" id="PreviewUpdateToastButton" type="button" data-i18n="previewUpdateToastButton">Preview</button>
-        </div>
-
-        <div class="setting-row">
-          <div>
-            <h3 data-i18n="gradesDebug">Grades Attendance Debug</h3>
-            <p data-i18n="gradesDebugDesc">Print detailed fetch, parsing, matching, and rendering diagnostics for the grades attendance feature into the browser console.</p>
-          </div>
-          <label class="switch switch-compact" for="GradesAttendanceDebugCheckbox">
-            <input type="checkbox" id="GradesAttendanceDebugCheckbox">
-            <span class="switch-track" aria-hidden="true"></span>
-            <span class="sr-only" data-i18n="toggleGradesDebug">Toggle grades attendance debug</span>
-          </label>
-        </div>
-
-        <div class="setting-row setting-row-stack">
-          <div>
-            <h3 data-i18n="reportProblem">Report a Problem</h3>
-            <p data-i18n="reportProblemDesc">If a feature misbehaves on your school's EduPage, generate a diagnostic report so the issue can be fixed without access to your account. Open the affected EduPage page in another tab first, then generate the report.</p>
-          </div>
-          <div class="setting-stack-controls">
-            <label class="inline-checkbox" for="ReportRedactCheckbox">
-              <input type="checkbox" id="ReportRedactCheckbox" checked>
-              <span data-i18n="reportRedact">Hide personal data (recommended)</span>
-            </label>
-            <p class="setting-note" data-i18n="reportRedactNote">When enabled, the report includes page structure (tags, classes, layout) but no grades, names, marks, or other text values.</p>
-            <div class="actions-row">
-              <button class="secondary-button" id="GenerateReportButton" type="button" data-i18n="generateReport">Generate Report</button>
-              <button class="secondary-button" id="CopyReportButton" type="button" data-i18n="copyReport" disabled>Copy</button>
-              <button class="secondary-button" id="DownloadReportButton" type="button" data-i18n="downloadReport" disabled>Download .json</button>
-              <button class="secondary-button" id="OpenIssueButton" type="button" data-i18n="openIssue" disabled>Open GitHub Issue</button>
-              <a class="secondary-button" href="https://discord.gg/eNZXHesA9j" target="_blank" rel="noopener noreferrer" data-i18n="reportDiscord">Report on Discord</a>
+        <div class="setting-card">
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="previewUpdateToast">Preview Update Toast</h3>
+              <p data-i18n="previewUpdateToastDesc">Show the "what's new" toast on an open Edupage tab right now, without waiting for an actual version change.</p>
             </div>
-            <p id="ReportStatus" class="setting-note" role="status" aria-live="polite"></p>
-            <textarea id="ReportOutput" class="report-output" readonly hidden aria-label="Diagnostic report"></textarea>
+            <button class="secondary-button" id="PreviewUpdateToastButton" type="button" data-i18n="previewUpdateToastButton">Preview</button>
+          </div>
+
+          <div class="setting-row">
+            <div>
+              <h3 data-i18n="gradesDebug">Grades Attendance Debug</h3>
+              <p data-i18n="gradesDebugDesc">Print detailed fetch, parsing, matching, and rendering diagnostics for the grades attendance feature into the browser console.</p>
+            </div>
+            <label class="switch switch-compact" for="GradesAttendanceDebugCheckbox">
+              <input type="checkbox" id="GradesAttendanceDebugCheckbox">
+              <span class="switch-track" aria-hidden="true"></span>
+              <span class="sr-only" data-i18n="toggleGradesDebug">Toggle grades attendance debug</span>
+            </label>
+          </div>
+
+          <div class="setting-row setting-row-stack">
+            <div>
+              <h3 data-i18n="reportProblem">Report a Problem</h3>
+              <p data-i18n="reportProblemDesc">If a feature misbehaves on your school's EduPage, generate a diagnostic report so the issue can be fixed without access to your account. Open the affected EduPage page in another tab first, then generate the report.</p>
+            </div>
+            <div class="setting-stack-controls">
+              <label class="inline-checkbox" for="ReportRedactCheckbox">
+                <input type="checkbox" id="ReportRedactCheckbox" checked>
+                <span data-i18n="reportRedact">Hide personal data (recommended)</span>
+              </label>
+              <p class="setting-note" data-i18n="reportRedactNote">When enabled, the report includes page structure (tags, classes, layout) but no grades, names, marks, or other text values.</p>
+              <div class="actions-row">
+                <button class="secondary-button" id="GenerateReportButton" type="button" data-i18n="generateReport">Generate Report</button>
+                <button class="secondary-button" id="CopyReportButton" type="button" data-i18n="copyReport" disabled>Copy</button>
+                <button class="secondary-button" id="DownloadReportButton" type="button" data-i18n="downloadReport" disabled>Download .json</button>
+                <button class="secondary-button" id="OpenIssueButton" type="button" data-i18n="openIssue" disabled>Open GitHub Issue</button>
+                <a class="secondary-button" href="https://discord.gg/eNZXHesA9j" target="_blank" rel="noopener noreferrer" data-i18n="reportDiscord">Report on Discord</a>
+              </div>
+              <p id="ReportStatus" class="setting-note" role="status" aria-live="polite"></p>
+              <textarea id="ReportOutput" class="report-output" readonly hidden aria-label="Diagnostic report"></textarea>
+            </div>
           </div>
         </div>
       </section>
@@ -436,33 +467,35 @@
       <section class="setting-group" id="panel-experimental" role="tabpanel" aria-labelledby="experimental-heading ExperimentalSettingsButton" tabindex="0" hidden>
         <div id="ExperimentalContent" hidden>
           <h2 id="experimental-heading" data-i18n="experimentalHeading">Experimental</h2>
-          <p data-i18n="experimentalSubtitle">Test activity and visibility protections on Edupage pages.</p>
-          <p><a class="inline-link" href="https://edublurtesting.ct.ws/" target="_blank" rel="noopener noreferrer" data-i18n="openTestingSite">Open the testing website</a></p>
+          <p class="setting-group-subtitle" data-i18n="experimentalSubtitle">Test activity and visibility protections on Edupage pages.</p>
+          <p class="setting-group-subtitle"><a class="inline-link" href="https://edublurtesting.ct.ws/" target="_blank" rel="noopener noreferrer" data-i18n="openTestingSite">Open the testing website</a></p>
           <div class="section-heading">
             <h3 id="activity-heading" data-i18n="samHeading">Stay Active Mode</h3>
             <p data-i18n="samDesc">Controls how Edupage sees tab activity, focus, mouse movement, and clipboard actions. Changes apply live, but reloading open Edupage tabs gives the cleanest start.</p>
           </div>
 
-          <div class="setting-row prominent-row">
-            <div>
-              <h3 data-i18n="samMaster">Stay Active Mode (Master Switch)</h3>
-              <p data-i18n="samMasterDesc">Turn the full Stay Active feature set on or off at once for Edupage pages.</p>
+          <div class="setting-card">
+            <div class="setting-row prominent-row">
+              <div>
+                <h3 data-i18n="samMaster">Stay Active Mode (Master Switch)</h3>
+                <p data-i18n="samMasterDesc">Turn the full Stay Active feature set on or off at once for Edupage pages.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityShieldEnabled">
+                <input type="checkbox" id="ActivityShieldEnabled">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleSam">Toggle Stay Active Mode</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityShieldEnabled">
-              <input type="checkbox" id="ActivityShieldEnabled">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleSam">Toggle Stay Active Mode</span>
-            </label>
-          </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="samHotkey">Master Switch Hotkey</h3>
-              <p data-i18n="samHotkeyDesc">Optional. No default hotkey is assigned. Use Chrome's extension shortcuts page if you want a shortcut for toggling Stay Active Mode.</p>
-            </div>
-            <div class="shortcut-controls">
-              <button class="secondary-button" id="ExperimentalShortcutSettingsButton" type="button" data-i18n="openShortcutSettings">Open Shortcut Settings</button>
-              <span class="shortcut-status" id="ActivityShieldShortcutStatus" data-i18n="noHotkey">No hotkey assigned.</span>
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="samHotkey">Master Switch Hotkey</h3>
+                <p data-i18n="samHotkeyDesc">Optional. No default hotkey is assigned. Use Chrome's extension shortcuts page if you want a shortcut for toggling Stay Active Mode.</p>
+              </div>
+              <div class="shortcut-controls">
+                <button class="secondary-button" id="ExperimentalShortcutSettingsButton" type="button" data-i18n="openShortcutSettings">Open Shortcut Settings</button>
+                <span class="shortcut-status" id="ActivityShieldShortcutStatus" data-i18n="noHotkey">No hotkey assigned.</span>
+              </div>
             </div>
           </div>
 
@@ -470,168 +503,174 @@
             <h3 id="spoofing-heading" data-i18n="sectVisibility">Visibility & Focus</h3>
           </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="keepVisible">Keep Tab Marked Visible</h3>
-              <p data-i18n-html="keepVisibleDesc">Make Edupage read the tab as <code>visible</code> even after switching away.</p>
+          <div class="setting-card">
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="keepVisible">Keep Tab Marked Visible</h3>
+                <p data-i18n-html="keepVisibleDesc">Make Edupage read the tab as <code>visible</code> even after switching away.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityVisibilityState">
+                <input type="checkbox" id="ActivityVisibilityState">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleKeepVisible">Toggle keep tab marked visible</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityVisibilityState">
-              <input type="checkbox" id="ActivityVisibilityState">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleKeepVisible">Toggle keep tab marked visible</span>
-            </label>
-          </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="keepNotHidden">Keep Tab Marked Not Hidden</h3>
-              <p data-i18n-html="keepNotHiddenDesc">Make Edupage read <code>document.hidden</code> as <code>false</code>.</p>
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="keepNotHidden">Keep Tab Marked Not Hidden</h3>
+                <p data-i18n-html="keepNotHiddenDesc">Make Edupage read <code>document.hidden</code> as <code>false</code>.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityHidden">
+                <input type="checkbox" id="ActivityHidden">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleKeepNotHidden">Toggle keep tab marked not hidden</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityHidden">
-              <input type="checkbox" id="ActivityHidden">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleKeepNotHidden">Toggle keep tab marked not hidden</span>
-            </label>
-          </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="hideTabSwitch">Hide Tab-Switch Events</h3>
-              <p data-i18n="hideTabSwitchDesc">Stop Edupage scripts from receiving visibility and page-hide events.</p>
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="hideTabSwitch">Hide Tab-Switch Events</h3>
+                <p data-i18n="hideTabSwitchDesc">Stop Edupage scripts from receiving visibility and page-hide events.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityVisibilityEvents">
+                <input type="checkbox" id="ActivityVisibilityEvents">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleHideTabSwitch">Toggle hide tab-switch events</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityVisibilityEvents">
-              <input type="checkbox" id="ActivityVisibilityEvents">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleHideTabSwitch">Toggle hide tab-switch events</span>
-            </label>
-          </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="keepFocused">Keep Page Marked Focused</h3>
-              <p data-i18n="keepFocusedDesc">Make Edupage read the page as focused and hide focus-in events.</p>
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="keepFocused">Keep Page Marked Focused</h3>
+                <p data-i18n="keepFocusedDesc">Make Edupage read the page as focused and hide focus-in events.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityFocus">
+                <input type="checkbox" id="ActivityFocus">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleKeepFocused">Toggle keep page marked focused</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityFocus">
-              <input type="checkbox" id="ActivityFocus">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleKeepFocused">Toggle keep page marked focused</span>
-            </label>
-          </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="hideFocusLoss">Hide Focus Loss</h3>
-              <p data-i18n="hideFocusLossDesc">Stop Edupage scripts from receiving blur and focus-out events.</p>
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="hideFocusLoss">Hide Focus Loss</h3>
+                <p data-i18n="hideFocusLossDesc">Stop Edupage scripts from receiving blur and focus-out events.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityBlur">
+                <input type="checkbox" id="ActivityBlur">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleHideFocusLoss">Toggle hide focus loss</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityBlur">
-              <input type="checkbox" id="ActivityBlur">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleHideFocusLoss">Toggle hide focus loss</span>
-            </label>
           </div>
 
           <div class="section-heading">
             <h3 id="input-heading" data-i18n="sectInput">Mouse & Input</h3>
           </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="hideCursorLeave">Hide Cursor Leaving The Page</h3>
-              <p data-i18n="hideCursorLeaveDesc">Stop Edupage scripts from seeing mouse enter and leave events.</p>
+          <div class="setting-card">
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="hideCursorLeave">Hide Cursor Leaving The Page</h3>
+                <p data-i18n="hideCursorLeaveDesc">Stop Edupage scripts from seeing mouse enter and leave events.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityMouseleave">
+                <input type="checkbox" id="ActivityMouseleave">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleHideCursorLeave">Toggle hide cursor leaving the page</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityMouseleave">
-              <input type="checkbox" id="ActivityMouseleave">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleHideCursorLeave">Toggle hide cursor leaving the page</span>
-            </label>
-          </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="hideCursorMove">Hide Cursor Moving Between Areas</h3>
-              <p data-i18n="hideCursorMoveDesc">Stop Edupage scripts from seeing mouse over and out events.</p>
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="hideCursorMove">Hide Cursor Moving Between Areas</h3>
+                <p data-i18n="hideCursorMoveDesc">Stop Edupage scripts from seeing mouse over and out events.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityMouseout">
+                <input type="checkbox" id="ActivityMouseout">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleHideCursorMove">Toggle hide cursor moving between areas</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityMouseout">
-              <input type="checkbox" id="ActivityMouseout">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleHideCursorMove">Toggle hide cursor moving between areas</span>
-            </label>
-          </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="hidePointerCapture">Hide Pointer Capture Changes</h3>
-              <p data-i18n="hidePointerCaptureDesc">Stop Edupage scripts from seeing pointer capture and release events.</p>
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="hidePointerCapture">Hide Pointer Capture Changes</h3>
+                <p data-i18n="hidePointerCaptureDesc">Stop Edupage scripts from seeing pointer capture and release events.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityPointercapture">
+                <input type="checkbox" id="ActivityPointercapture">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleHidePointerCapture">Toggle hide pointer capture changes</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityPointercapture">
-              <input type="checkbox" id="ActivityPointercapture">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleHidePointerCapture">Toggle hide pointer capture changes</span>
-            </label>
-          </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="hideClipboard">Hide Copy, Paste, Selection, And Dragging</h3>
-              <p data-i18n="hideClipboardDesc">Stop Edupage scripts from seeing clipboard, context menu, selection, drag, and drop events.</p>
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="hideClipboard">Hide Copy, Paste, Selection, And Dragging</h3>
+                <p data-i18n="hideClipboardDesc">Stop Edupage scripts from seeing clipboard, context menu, selection, drag, and drop events.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityClipboard">
+                <input type="checkbox" id="ActivityClipboard">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleHideClipboard">Toggle hide copy paste selection and dragging</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityClipboard">
-              <input type="checkbox" id="ActivityClipboard">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleHideClipboard">Toggle hide copy paste selection and dragging</span>
-            </label>
           </div>
 
           <div class="section-heading">
             <h3 id="background-heading" data-i18n="sectBackground">Background Behavior</h3>
           </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="stopRedirects">Stop Hidden-Tab Reload Redirects</h3>
-              <p data-i18n="stopRedirectsDesc">Try to block reload redirects that start after Edupage becomes hidden.</p>
+          <div class="setting-card">
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="stopRedirects">Stop Hidden-Tab Reload Redirects</h3>
+                <p data-i18n="stopRedirectsDesc">Try to block reload redirects that start after Edupage becomes hidden.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityRedirect">
+                <input type="checkbox" id="ActivityRedirect">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleStopRedirects">Toggle hidden-tab reload redirects</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityRedirect">
-              <input type="checkbox" id="ActivityRedirect">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleStopRedirects">Toggle hidden-tab reload redirects</span>
-            </label>
-          </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="keepAnimation">Keep Page Animation Running In Background</h3>
-              <p data-i18n-html="keepAnimationDesc">Keep <code>requestAnimationFrame</code> callbacks moving while the tab is hidden.</p>
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="keepAnimation">Keep Page Animation Running In Background</h3>
+                <p data-i18n-html="keepAnimationDesc">Keep <code>requestAnimationFrame</code> callbacks moving while the tab is hidden.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityAnimationFrame">
+                <input type="checkbox" id="ActivityAnimationFrame">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleKeepAnimation">Toggle keep page animation running in background</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityAnimationFrame">
-              <input type="checkbox" id="ActivityAnimationFrame">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleKeepAnimation">Toggle keep page animation running in background</span>
-            </label>
-          </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="showStatusDot">Show Status Dot On Edupage</h3>
-              <p data-i18n="showStatusDotDesc">Show a small dot so users can see whether Stay Active Mode is active or paused.</p>
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="showStatusDot">Show Status Dot On Edupage</h3>
+                <p data-i18n="showStatusDotDesc">Show a small dot so users can see whether Stay Active Mode is active or paused.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityVisualIndicator">
+                <input type="checkbox" id="ActivityVisualIndicator">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleShowStatusDot">Toggle status dot on Edupage</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityVisualIndicator">
-              <input type="checkbox" id="ActivityVisualIndicator">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleShowStatusDot">Toggle status dot on Edupage</span>
-            </label>
-          </div>
 
-          <div class="setting-row">
-            <div>
-              <h3 data-i18n="showConsoleDebug">Show Console Debug Messages</h3>
-              <p data-i18n="showConsoleDebugDesc">Print technical diagnostics in the page console when something cannot be changed.</p>
+            <div class="setting-row">
+              <div>
+                <h3 data-i18n="showConsoleDebug">Show Console Debug Messages</h3>
+                <p data-i18n="showConsoleDebugDesc">Print technical diagnostics in the page console when something cannot be changed.</p>
+              </div>
+              <label class="switch switch-compact" for="ActivityLog">
+                <input type="checkbox" id="ActivityLog">
+                <span class="switch-track" aria-hidden="true"></span>
+                <span class="sr-only" data-i18n="toggleShowConsoleDebug">Toggle console debug messages</span>
+              </label>
             </div>
-            <label class="switch switch-compact" for="ActivityLog">
-              <input type="checkbox" id="ActivityLog">
-              <span class="switch-track" aria-hidden="true"></span>
-              <span class="sr-only" data-i18n="toggleShowConsoleDebug">Toggle console debug messages</span>
-            </label>
           </div>
 
           <div class="section-heading">
@@ -650,7 +689,7 @@
       </div>
 
       <footer class="made-by">
-        <span data-i18n="madeBy">Made by</span> <a href="https://github.com/Alexosavrua" target="_blank" rel="noopener noreferrer">JustAlex</a>
+        <span data-i18n="madeBy">Made by</span> <a href="https://github.com/Alexosavrua" target="_blank" rel="noopener noreferrer">JustAlex</a> <a class="made-by-contributors" href="https://github.com/Alexosavrua/Edupage-Extras/graphs/contributors" target="_blank" rel="noopener noreferrer" data-i18n="madeByContributors">and contributors</a>
       </footer>
 
       <dialog class="confirm-dialog" id="ExperimentalConfirmDialog" aria-labelledby="experimental-confirm-title">

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -826,58 +826,114 @@ function buildMobileResponsiveCSS() {
   const M = "html.ee-mobile-responsive";
   return `
     @media (max-width: 768px) {
-      /* ── Global ────────────────────────────────────── */
+      /* ── Global guards ──────────────────────────────────
+         Nothing may force the layout viewport wider than the
+         screen: hidden overflow as the last resort, fluid media,
+         and breakable long words (links, filenames, teacher
+         emails) inside content cards. */
       ${M} body {
         overflow-x: hidden !important;
         -webkit-text-size-adjust: 100% !important;
       }
 
-      /* ── Fixed-width containers → fluid ────────────── */
+      ${M} img {
+        max-width: 100% !important;
+        height: auto !important;
+      }
+
+      ${M} iframe,
+      ${M} video,
+      ${M} canvas,
+      ${M} embed,
+      ${M} object {
+        max-width: 100% !important;
+      }
+
+      ${M} .userButton,
+      ${M} .userHomeWidget,
+      ${M} .userHomeOther,
+      ${M} .timeline-item,
+      ${M} .tml-item,
+      ${M} .tml-in-reply,
+      ${M} .hwItem,
+      ${M} .hw-content,
+      ${M} .notifBox {
+        overflow-wrap: anywhere !important;
+        word-break: break-word !important;
+      }
+
+      /* ── Fixed-width containers → fluid ─────────────────
+         Also strip left/right margins and floats: the desktop
+         layout reserves a gutter for the sidebar column, which
+         otherwise survives as dead space once the sidebar is
+         repositioned. */
       ${M} .userTopDivInner,
       ${M} .wmaxL1,
       ${M} .userRozvrh,
       ${M} .skinContent,
+      ${M} .skinBody,
       ${M} .userContentInner,
       ${M} .mainBox,
+      ${M} .bgDiv,
+      ${M} .withMargin,
+      ${M} .edubarMain,
+      ${M} .edubarMainNoSkin,
       ${M} #eb_main_content,
       ${M} #bar_mainDiv,
       ${M} .hwMainListMain {
-        flex-wrap: wrap !important;
         width: auto !important;
         max-width: 100% !important;
         min-width: 0 !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+        float: none !important;
         box-sizing: border-box !important;
       }
 
-      /* ── Sidebar → collapsed above content ─────────── */
+      /* ── Sidebar → horizontal chip rail ─────────────────
+         A wrapped wall of menu pills eats half a phone screen
+         before any content shows. One compact row that scrolls
+         sideways (like every mobile tab bar) keeps the menu
+         reachable and the content on top. */
       ${M} .edubarSidebar,
       ${M} .edubarSidemenu2 {
         position: static !important;
+        float: none !important;
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        align-items: stretch !important;
         width: 100% !important;
         min-width: 0 !important;
+        max-width: 100% !important;
         max-height: none !important;
-        overflow: visible !important;
-        float: none !important;
-      }
-
-      ${M} .edubarSidebar {
-        display: flex !important;
-        flex-wrap: wrap !important;
+        overflow-x: auto !important;
+        overflow-y: hidden !important;
+        -webkit-overflow-scrolling: touch !important;
         gap: 2px !important;
         padding: 4px !important;
+        box-sizing: border-box !important;
+        scrollbar-width: thin !important;
+      }
+
+      ${M} .edubarSidebar::-webkit-scrollbar,
+      ${M} .edubarSidemenu2::-webkit-scrollbar {
+        height: 4px !important;
       }
 
       ${M} .edubarMenuitem {
-        flex: 1 1 auto !important;
+        flex: 0 0 auto !important;
+        width: auto !important;
         min-width: 0 !important;
       }
 
       ${M} .edubarMenuitem > a {
-        padding: 8px 10px !important;
+        display: inline-flex !important;
+        align-items: center !important;
+        min-height: 40px !important;
+        padding: 6px 12px !important;
         font-size: 13px !important;
         white-space: nowrap !important;
-        overflow: hidden !important;
-        text-overflow: ellipsis !important;
+        box-sizing: border-box !important;
       }
 
       /* ── Top bar compact ────────────────────────────── */
@@ -885,6 +941,7 @@ function buildMobileResponsiveCSS() {
       ${M} .edubarHeader {
         flex-wrap: wrap !important;
         min-height: 0 !important;
+        max-width: 100% !important;
       }
 
       ${M} .edubarHeaderRight {
@@ -905,11 +962,10 @@ function buildMobileResponsiveCSS() {
         font-size: 13px !important;
       }
 
-      /* ── Main content area full-width ───────────────── */
+      /* ── Main content column ────────────────────────── */
       ${M} .skinBody {
         display: flex !important;
         flex-direction: column !important;
-        min-width: 0 !important;
       }
 
       ${M} .edubarMainNoSkin {
@@ -925,6 +981,7 @@ function buildMobileResponsiveCSS() {
 
       ${M} .userTopDivInner {
         flex-direction: column !important;
+        flex-wrap: wrap !important;
       }
 
       ${M} .userButton,
@@ -940,16 +997,22 @@ function buildMobileResponsiveCSS() {
         font-size: 14px !important;
       }
 
-      /* ── Timetable strip → full-width, scrollable ──── */
+      /* ── Timetable strip → one row, swipeable ───────── */
       ${M} .userRozvrh {
         flex-direction: column !important;
       }
 
       ${M} ul.rozvrh {
+        display: flex !important;
+        flex-wrap: nowrap !important;
         overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
         max-width: 100% !important;
         padding: 0 !important;
+      }
+
+      ${M} ul.rozvrh > li {
+        flex: 0 0 auto !important;
       }
 
       ${M} .userStats {
@@ -1033,6 +1096,7 @@ function buildMobileResponsiveCSS() {
         left: 4px !important;
         right: 4px !important;
         bottom: auto !important;
+        width: auto !important;
         max-width: calc(100vw - 8px) !important;
         max-height: 90vh !important;
         overflow-y: auto !important;
@@ -1046,35 +1110,41 @@ function buildMobileResponsiveCSS() {
         overflow-x: auto !important;
       }
 
-      /* ── Buttons / interactive → touch-friendly ─────── */
-      ${M} .smartb,
-      ${M} .flat-button,
-      ${M} button,
-      ${M} .userButton a,
-      ${M} .edubarMenuitem > a {
-        min-height: 44px !important;
-        display: inline-flex !important;
-        align-items: center !important;
+      /* ── Forms & touch targets ──────────────────────────
+         16px text inputs stop iOS Safari from auto-zooming the
+         page on focus. The touch-size floor stays scoped to
+         real action buttons — a blanket "button {min-height:
+         44px}" inflates the small inline icon buttons EduPage
+         scatters through tables and toolbars. */
+      ${M} input[type="text"],
+      ${M} input[type="password"],
+      ${M} input[type="email"],
+      ${M} input[type="search"],
+      ${M} input[type="number"],
+      ${M} select,
+      ${M} textarea {
+        font-size: 16px !important;
+        max-width: 100% !important;
       }
 
-      /* ── Images → fluid ─────────────────────────────── */
-      ${M} img,
-      ${M} .user-button-icon {
-        max-width: 100% !important;
-        height: auto !important;
+      ${M} .smartb,
+      ${M} .flat-button {
+        min-height: 40px !important;
+        box-sizing: border-box !important;
       }
 
       /* ── Grade filter bar → wrap ────────────────────── */
       ${M} .zsvHeader,
+      ${M} .zsvHeaderTab,
       ${M} .zsvFilterElem,
       ${M} .zsvActionButtonsInner {
         flex-wrap: wrap !important;
         gap: 4px !important;
+        max-width: 100% !important;
       }
 
       ${M} .zsvFilterItem select {
         min-width: 100px !important;
-        font-size: 13px !important;
       }
 
       /* ── Attendance grid ────────────────────────────── */
@@ -1145,8 +1215,8 @@ function buildMobileResponsiveCSS() {
       }
 
       ${M} .edubarMenuitem > a {
-        padding: 6px 6px !important;
-        font-size: 11px !important;
+        padding: 5px 9px !important;
+        font-size: 12px !important;
       }
 
       ${M} .userButton,

--- a/tests/preview/chrome-shim.js
+++ b/tests/preview/chrome-shim.js
@@ -1,0 +1,91 @@
+/**
+ * chrome-shim.js — minimal chrome.* stub so menu.html / settings.html can be
+ * rendered in a plain browser tab for visual/dev work (see index.html).
+ * Never shipped: the tests/ folder is excluded from both store builds.
+ */
+(function () {
+  "use strict";
+
+  const cfg = window.__EE_PREVIEW__ || {};
+  const MESSAGES = cfg.messages || {};
+  const VERSION = "0.0.0-preview";
+
+  const store = Object.assign(
+    {
+      darkModeEnabled: cfg.enabled !== false,
+      themeMode: cfg.theme || "dark",
+      eeUpdateStatus: {
+        localVersion: VERSION,
+        latestVersion: cfg.update ? "9.9.9" : VERSION,
+        updateAvailable: !!cfg.update,
+        checkedAt: 1750000000000,
+      },
+    },
+    cfg.store || {},
+  );
+
+  function getMessage(key, substitutions) {
+    const entry = MESSAGES[key];
+    if (!entry) return "";
+    let msg = entry.message || "";
+    const list = substitutions == null ? [] : [].concat(substitutions);
+    if (entry.placeholders) {
+      for (const [name, def] of Object.entries(entry.placeholders)) {
+        const index = parseInt(String(def.content || "").replace("$", ""), 10) - 1;
+        msg = msg.split("$" + name + "$").join(String(list[index] ?? ""));
+      }
+    }
+    return msg.replace(/\$(\d)/g, (whole, n) => String(list[Number(n) - 1] ?? whole));
+  }
+
+  // Real chrome.* callbacks are async; mirror that so page scripts and the
+  // DOMContentLoaded i18n pass run in the same order as in the extension.
+  const later = (fn) => setTimeout(fn, 0);
+
+  window.chrome = {
+    storage: {
+      local: {
+        get(keys, cb) {
+          const defaults = keys && typeof keys === "object" && !Array.isArray(keys) ? keys : {};
+          later(() => cb(Object.assign({}, defaults, store)));
+        },
+        set(items, cb) {
+          Object.assign(store, items);
+          if (cb) later(cb);
+        },
+        remove(keys, cb) {
+          [].concat(keys).forEach((key) => delete store[key]);
+          if (cb) later(cb);
+        },
+      },
+      onChanged: { addListener() {} },
+    },
+    runtime: {
+      getManifest: () => ({ version: VERSION }),
+      sendMessage(message, cb) {
+        if (cb) later(() => cb({ ok: true, status: store.eeUpdateStatus }));
+      },
+      openOptionsPage() {
+        window.top.location.search = "?page=settings" + (window.top.location.search.replace(/^\?(page=[a-z]+&?)?/, "&"));
+      },
+      lastError: undefined,
+    },
+    i18n: {
+      getMessage,
+      getUILanguage: () => "en",
+    },
+    commands: {
+      getAll(cb) {
+        later(() => cb([]));
+      },
+    },
+    tabs: {
+      query(query, cb) {
+        later(() => cb([]));
+      },
+      create() {},
+      sendMessage() {},
+      reload() {},
+    },
+  };
+})();

--- a/tests/preview/edupage-mock.html
+++ b/tests/preview/edupage-mock.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<!--
+  Dev-only structural mock of the EduPage shell (real class names, fake
+  desktop styles) to exercise buildMobileResponsiveCSS() from
+  scripts/content.js without an EduPage account.
+
+  Serve the repo root over HTTP, then open:
+    /tests/preview/edupage-mock.html        -> fix ON
+    /tests/preview/edupage-mock.html?off=1  -> fix OFF (raw desktop layout)
+
+  Never shipped: tests/ is excluded from both store builds.
+-->
+<html lang="en" class="ee-mobile-responsive">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>EduPage shell mock</title>
+    <style>
+      /* Crude stand-ins for EduPage's own desktop styles: fixed widths,
+         floated sidebar, reserved gutter — the things that break phones. */
+      body { margin: 0; font: 13px/1.4 Arial, sans-serif; background: #f2f4f7; }
+      #edubar { display: flex; align-items: center; background: #2c70a3; color: #fff; padding: 6px 10px; }
+      .edubarHeaderRight { display: flex; margin-left: auto; gap: 8px; }
+      .edubarProfilebox { background: #24618d; padding: 6px 14px; white-space: nowrap; }
+      .skinBody { min-height: 400px; }
+      .edubarSidebar { float: left; width: 220px; background: #1b2838; padding: 8px 0; }
+      .edubarMenuitem > a { display: block; color: #cfd8e3; padding: 9px 16px; text-decoration: none; white-space: nowrap; }
+      .edubarMainNoSkin { margin-left: 220px; padding: 12px; }
+      #eb_main_content { width: 960px; }
+      .userTopDiv { display: flex; background: #0e1622; color: #fff; }
+      .userTopDivInner { display: flex; width: 940px; margin: 0 auto; }
+      .userRozvrh { display: flex; }
+      ul.rozvrh { list-style: none; margin: 0; padding: 0; width: 900px; display: flex; }
+      ul.rozvrh li { min-width: 86px; border: 1px solid #26364c; padding: 8px 6px; }
+      .userButton { float: left; width: 300px; background: #fff; border: 1px solid #d8dee7; margin: 8px; padding: 12px; }
+      table.znamkyTable { border-collapse: collapse; width: 900px; background: #fff; }
+      table.znamkyTable td, table.znamkyTable th { border: 1px solid #d8dee7; padding: 6px 10px; white-space: nowrap; }
+      .clear { clear: both; }
+    </style>
+    <script>
+      (async function () {
+        if (new URLSearchParams(location.search).get("off") === "1") {
+          document.documentElement.classList.remove("ee-mobile-responsive");
+          return;
+        }
+        const src = await (await fetch("/scripts/content.js")).text();
+        const start = src.indexOf("function buildMobileResponsiveCSS");
+        const end = src.indexOf("\nfunction ", start + 10);
+        const style = document.createElement("style");
+        style.textContent = new Function(src.slice(start, end) + "; return buildMobileResponsiveCSS();")();
+        document.head.appendChild(style);
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="edubar">
+      <div class="edubarHeader">EduPage — Gymnázium Example</div>
+      <div class="edubarHeaderRight">
+        <div class="edubarProfilebox"><span class="display">Jozef Mrkvička (študent)</span></div>
+        <button id="edubarStartButton">Start</button>
+      </div>
+    </div>
+    <div class="skinBody">
+      <div class="edubarSidebar">
+        <div class="edubarMenuitem"><a href="#">Úvod</a></div>
+        <div class="edubarMenuitem"><a href="#">Správy</a></div>
+        <div class="edubarMenuitem"><a href="#">Rozvrh hodín</a></div>
+        <div class="edubarMenuitem"><a href="#">Známky</a></div>
+        <div class="edubarMenuitem"><a href="#">Dochádzka</a></div>
+        <div class="edubarMenuitem"><a href="#">Domáce úlohy</a></div>
+        <div class="edubarMenuitem"><a href="#">Učivo</a></div>
+        <div class="edubarMenuitem"><a href="#">Prihlasovanie</a></div>
+        <div class="edubarMenuitem"><a href="#">Platby</a></div>
+        <div class="edubarMenuitem"><a href="#">Školská jedáleň</a></div>
+      </div>
+      <div class="edubarMainNoSkin">
+        <div id="eb_main_content">
+          <div class="userTopDiv">
+            <div class="userTopDivInner">
+              <div class="userRozvrh">
+                <ul class="rozvrh">
+                  <li>1<br>SJL<br>U12</li><li>2<br>MAT<br>U04</li><li>3<br>ANJ<br>J2</li>
+                  <li>4<br>FYZ<br>LabF</li><li>5<br>TSV<br>Telocvičňa</li><li>6<br>INF<br>PC1</li>
+                  <li>7<br>DEJ<br>U09</li><li>8<br>—</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="userButton"><b>Najnovšie správy</b><br>Zajtra písomka z matematiky — kvadratické-rovnice-a-nerovnice.pdf</div>
+          <div class="userButton"><b>Domáce úlohy</b><br>ANJ: Workbook p. 42, exercises 1–5</div>
+          <div class="userButton"><b>Suplovanie</b><br>3. hodina: FYZ → DEJ (Mgr. Novák), učebňa U09</div>
+          <div class="clear"></div>
+          <table class="znamkyTable">
+            <tr><th>Predmet</th><th>Priebežné</th><th>Polrok 1</th><th>Písomky</th><th>Ústne</th><th>Projekty</th><th>Priemer</th></tr>
+            <tr><td>Slovenský jazyk a literatúra</td><td>1, 2, 1</td><td>1</td><td>2, 1</td><td>1</td><td>1</td><td>1,29</td></tr>
+            <tr><td>Matematika</td><td>2, 3, 2</td><td>2</td><td>3, 2</td><td>2</td><td>1</td><td>2,14</td></tr>
+            <tr><td>Anglický jazyk</td><td>1, 1, 2</td><td>1</td><td>1, 2</td><td>1</td><td>1</td><td>1,25</td></tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/preview/index.html
+++ b/tests/preview/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<!--
+  Dev-only preview harness: renders menu/menu.html or menu/settings.html in a
+  plain browser (no extension runtime) by injecting chrome-shim.js.
+
+  Serve the repo root over HTTP, then open:
+    /tests/preview/index.html?page=settings&theme=dark&enabled=1&update=1
+      page:    menu | settings   (default settings)
+      theme:   dark | ocean | forest | emerald | pink | purple | light | custom
+      enabled: 1 | 0             (themes toggle on/off; 0 forces light)
+      update:  1                 (pretend an update is available)
+
+  Never shipped: tests/ is excluded from both store builds.
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Edupage Extras UI preview</title>
+    <style>
+      html, body { height: 100%; margin: 0; }
+      iframe { border: 0; display: block; height: 100%; width: 100%; }
+    </style>
+  </head>
+  <body>
+    <iframe id="frame" title="preview"></iframe>
+    <script>
+      (async function () {
+        const params = new URLSearchParams(location.search);
+        const page = params.get("page") === "menu" ? "menu" : "settings";
+        const cfg = {
+          theme: params.get("theme") || "dark",
+          enabled: params.get("enabled") !== "0",
+          update: params.get("update") === "1",
+          messages: await (await fetch("/_locales/en/messages.json")).json(),
+        };
+        const html = await (await fetch("/menu/" + page + ".html")).text();
+        const inject =
+          "<base href=\"/menu/\">" +
+          "<script>window.__EE_PREVIEW__ = " + JSON.stringify(cfg) + ";<\/script>" +
+          "<script src=\"/tests/preview/chrome-shim.js\"><\/script>";
+        document.getElementById("frame").srcdoc = html.replace(/<head>/i, "<head>" + inject);
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Settings page
- Each section is now a single card with hairline row dividers instead of a separate bordered box per setting.
- Sidebar nav gets icons, an accent indicator bar, and proper sticky positioning; keyboard navigation and all tab/ARIA wiring unchanged.
- On small screens the nav becomes a sticky, horizontally scrollable tab bar; only rows with wide controls (date pickers, shortcut/status blocks, color grids) stack vertically — simple toggle rows keep label-left / switch-right.
- Panel switch transition, consistent focus rings, empty status notes no longer render as empty boxes.

## Popup
- Header with the extension icon, name, and a version pill; icon chips on rows; update notice restyled as an accent-tinted card; SVG chevrons instead of text ">".

## Theming
- Accent/border tints are derived with `color-mix()` from the existing theme variables, so all 8 themes — including fully custom ones — recolor the entire UI (nav, chips, switches, glow) with no extra per-theme CSS. Switches use the theme accent instead of hardcoded green.

## Mobile-responsive layout (EduPage injection)
- The sidebar collapses into a horizontal, swipeable chip rail instead of a tall wall of wrapped pills.
- Main containers drop the left margin/float that reserved space for the desktop sidebar column (this left a dead gutter before).
- Timetable strip is explicitly nowrap + touch-scrollable; grades/attendance tables scroll in place.
- Removed the blanket `button { min-height: 44px }` rule that inflated small inline icon buttons; touch sizing is scoped to menu links and action buttons.
- 16px text inputs to stop iOS focus auto-zoom, `overflow-wrap: anywhere` on content cards, fluid images/iframes.

Verified with a structural mock of the EduPage shell (`tests/preview/edupage-mock.html`): at 375 px the stock layout measures 1193 px wide; with the fix enabled it reflows to exactly 375 px with no horizontal overflow. Needs a sanity pass on a real school instance.

## Footer
- "Made by JustAlex and contributors" — contributors links to the repo's contributors page, localized in en/sk/cs.

## Dev tooling
- `tests/preview/` renders both extension pages in a plain browser via a small `chrome.*` shim (plus the EduPage shell mock). Excluded from both store builds.

All 7 unit tests pass; `web-ext lint` reports no new issues; every `getElementById`/class hook used by menu.js/settings.js and all 181 i18n keys were cross-checked against the new markup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contributor attribution in the app footer, alongside the existing author credit.
  * Updated menu and settings screens with refreshed icons, labels, and button treatments.

* **Bug Fixes**
  * Improved small-screen behavior to reduce overflow and make menus, tables, and dialogs fit better on mobile.
  * Enhanced responsive layouts so key controls and lists scroll or wrap more naturally on narrow displays.

* **Style**
  * Introduced a broader visual refresh across the menu and settings pages, including updated theme colors, spacing, and interactive states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->