### PR TITLE
Fix blank /app/main on iPhone/iPad for the mobile redirect

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -89,6 +89,14 @@
       "match_about_blank": true
     },
     {
+      "matches": ["https://*.edupage.org/*"],
+      "js": ["scripts/ua-ios-fix.js"],
+      "run_at": "document_start",
+      "all_frames": true,
+      "match_about_blank": true,
+      "world": "MAIN"
+    },
+    {
       "matches": [
         "https://*.edupage.org/*",
         "https://edublurtesting.ct.ws/*"

--- a/scripts/ua-ios-fix.js
+++ b/scripts/ua-ios-fix.js
@@ -1,0 +1,39 @@
+/**
+ * ua-ios-fix.js - Edupage Extras: iOS mobile /app/main fix
+ *
+ * EduPage's /app/main React app hides the web login (rendering only an empty
+ * menu shell) whenever navigator.userAgent looks like iOS, to steer users into
+ * the native app. That is why the mobile /app/main redirect works on Android
+ * and desktop but shows a blank page on iPhone/iPad. Running in the MAIN world
+ * at document_start, we shadow navigator.userAgent with an Android *mobile* UA
+ * before EduPage's own scripts read it, so the responsive layout loads as it
+ * does everywhere else.
+ *
+ * Scoped to /app/* so no other iOS behaviour on the site changes. Isolated-world
+ * scripts (the redirect in content.js) keep seeing the real UA, so mobile
+ * detection and the redirect itself are unaffected.
+ */
+(() => {
+  "use strict";
+  const realUA = navigator.userAgent || "";
+  // Only iOS is gated by EduPage, and only /app/* is affected — bail otherwise.
+  if (!/iP(hone|ad|od)/i.test(realUA)) return;
+  if (!String(location.pathname || "").startsWith("/app/")) return;
+
+  // Keep "Mobile" in the UA so EduPage still serves the narrow responsive layout.
+  const UA =
+    "Mozilla/5.0 (Linux; Android 14; Mobile) AppleWebKit/537.36 " +
+    "(KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36";
+  const shadow = (obj, prop, value) => {
+    try {
+      Object.defineProperty(obj, prop, { get: () => value, configurable: true });
+    } catch (_) {
+      /* property non-configurable — skip */
+    }
+  };
+  shadow(Navigator.prototype, "userAgent", UA);
+  shadow(navigator, "userAgent", UA);
+  shadow(Navigator.prototype, "appVersion", "5.0 (Linux; Android 14; Mobile)");
+  shadow(Navigator.prototype, "platform", "Linux armv8l");
+  shadow(Navigator.prototype, "vendor", "Google Inc.");
+})();


### PR DESCRIPTION
### Problem

The mobile `/app/main` redirect works on Android and desktop but shows a blank page on iPhone/iPad. EduPage's `/app/main` React app hides the web login and renders only an empty menu shell whenever `navigator.userAgent` contains an iOS token (`iPhone`/`iPad`/`iPod`), to steer iOS users into the native app.

The gate is entirely client-side. The server returns the same shell to every user agent (it only adds `inobounce.js` for iOS), and the login is rendered by the app bundle after it reads `navigator.userAgent`. Overriding `navigator.userAgent` in the page is enough to fix it — the request header is not involved, so no new permissions are needed.

### Fix

Adds `scripts/ua-ios-fix.js`, a MAIN-world content script that runs at `document_start` and, on iOS only and only under `/app/*`, shadows `navigator.userAgent` (plus `appVersion`/`platform`/`vendor`) with an Android **mobile** UA before EduPage's scripts read it. Keeping `Mobile` in the UA preserves the responsive layout.

Scope is deliberately narrow:

- iOS user agents only; a no-op on every other platform.
- `/app/*` paths only, so no other iOS behaviour on the site changes.
- Runs in the MAIN world. The isolated-world redirect in `content.js` keeps seeing the real UA, so `isMobileUserAgent()` and the redirect trigger are unaffected.

### Testing

- `npm test` passes (23/23).
- Loaded unpacked with the browser UA forced to an iPhone string, then opened `/app/main`: without the change the app area is blank; with it the responsive login renders normally.

### Note

Current targets are Firefox desktop/Android, where the UA is never iOS, so this is a no-op there. It takes effect on WebKit/iOS builds (e.g. a Safari Web Extension), where the gate actually applies.
