### PR TITLE
Fire the mobile /app/main redirect on iOS regardless of userAgentData

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -29,12 +29,23 @@ const ACTIVITY_SHIELD_ENABLED_KEY = "eeActivityShieldEnabled";
 // screen reached after submitting, so all three need to be watched.
 const ETEST_PLAYER_ACTIVE_SELECTOR = ".etest-player-header, .etest-player-content, .etest-player-sideoverlay";
 
-function isMobileUserAgent() {
-  if (navigator.userAgentData && typeof navigator.userAgentData.mobile === "boolean") {
-    return navigator.userAgentData.mobile;
+// iPhone/iPad/iPod in the UA must win before consulting userAgentData: iOS
+// Safari never exposes navigator.userAgentData, and a spoofed UA string
+// (DevTools, a UA switcher, desktop "request mobile site") leaves
+// userAgentData.mobile === false, which would otherwise suppress the redirect
+// on iOS even though the UA clearly says iPhone.
+function isMobileUA(userAgent, userAgentData) {
+  const ua = userAgent || "";
+  if (/iP(hone|ad|od)/i.test(ua)) return true;
+  if (userAgentData && typeof userAgentData.mobile === "boolean") {
+    return userAgentData.mobile;
   }
   // Firefox for Android has no userAgentData — fall back to UA sniff.
-  return /Android|Mobile/i.test(navigator.userAgent || "");
+  return /Android|Mobile/i.test(ua);
+}
+
+function isMobileUserAgent() {
+  return isMobileUA(navigator.userAgent, navigator.userAgentData);
 }
 
 function shouldRedirectMobileToApp(pathname, mobile, enabled) {
@@ -1783,6 +1794,7 @@ if (globalThis.__EE_TEST__) {
     shouldSuppressThemeForPath,
     resolveAppliedTheme,
     isEtestAutoThemeOffActive,
+    isMobileUA,
     shouldRedirectMobileToApp,
   };
 }

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -157,6 +157,29 @@ runTest("mobile redirect follows the current opt-in and never redirects app rout
   assert.equal(shouldRedirectMobileToApp("/app/main", true, true), false);
 });
 
+runTest("mobile detection treats iOS as mobile even when userAgentData disagrees", () => {
+  const { isMobileUA } = loadContentInternals("/dashboard");
+
+  const iphone = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1";
+  const ipad = "Mozilla/5.0 (iPad; CPU OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1";
+  const androidChrome = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36";
+  const firefoxAndroid = "Mozilla/5.0 (Android 14; Mobile; rv:142.0) Gecko/142.0 Firefox/142.0";
+  const desktopChrome = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
+
+  // iOS Safari exposes no userAgentData — UA sniff alone catches it.
+  assert.equal(isMobileUA(iphone, undefined), true);
+  // Chromium keeps userAgentData.mobile === false under a spoofed iOS UA
+  // string (DevTools / UA switcher); the iPhone/iPad token must still win.
+  assert.equal(isMobileUA(iphone, { mobile: false }), true);
+  assert.equal(isMobileUA(ipad, { mobile: false }), true);
+  // Real userAgentData is authoritative when the UA is not iOS.
+  assert.equal(isMobileUA(androidChrome, { mobile: true }), true);
+  assert.equal(isMobileUA(desktopChrome, { mobile: false }), false);
+  // No userAgentData (Firefox) falls back to the UA sniff.
+  assert.equal(isMobileUA(firefoxAndroid, undefined), true);
+  assert.equal(isMobileUA(desktopChrome, undefined), false);
+});
+
 runTest("an active eTest player suppresses the theme only when auto-off is enabled", () => {
   const { resolveAppliedTheme } = loadContentInternals("/dashboard");
 


### PR DESCRIPTION
Follow-up to #65. That PR made `/app/main` render on iOS; this makes the redirect that sends users there actually fire on iOS.

### Problem

`isMobileUserAgent()` consulted `navigator.userAgentData.mobile` first. On Chromium that bit stays `false` under a spoofed iOS UA *string* (DevTools device mode, a UA switcher, desktop "request mobile site"), so the opt-in `/app/main` redirect was skipped even though the UA clearly said iPhone. Reproduced with an iOS UA on Chromium: `userAgentData.mobile === false` → `isMobileUserAgent()` returned `false`, no redirect.

(On a real iPhone, Safari exposes no `userAgentData`, so the existing `Android|Mobile` sniff already caught it — but every Chromium-based test/spoof path was broken.)

### Fix

`iPhone`/`iPad`/`iPod` in the UA now wins first, then `userAgentData.mobile`, then the existing `Android|Mobile` sniff. The logic is extracted into a pure `isMobileUA(userAgent, userAgentData)` so it can be unit-tested directly.

### Testing

- `npm test` passes, including new `isMobileUA` cases: iOS with no `userAgentData`, iOS with `userAgentData.mobile === false` (the spoof case), Android Chrome, Firefox Android, and desktop.
- Loaded unpacked with the browser UA set to an iPhone string and the redirect enabled: opening a normal school page now redirects to `/app/main` (previously it stayed on the desktop page).
